### PR TITLE
Allow use of latest local or remote smithy dependencies

### DIFF
--- a/examples/projection/build.gradle.kts
+++ b/examples/projection/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 buildscript {
     repositories {
         mavenLocal()
+        mavenCentral()
     }
     dependencies {
         // This dependency is required to build the model.

--- a/examples/projection/settings.gradle.kts
+++ b/examples/projection/settings.gradle.kts
@@ -3,8 +3,8 @@ rootProject.name = "projection"
 pluginManagement {
     repositories {
         mavenLocal()
+        mavenCentral()
         // Uncomment these to use the published version of the plugin from your preferred source.
         // gradlePluginPortal()
-        // mavenCentral()
     }
 }


### PR DESCRIPTION
### Description of changes
In general ` ./gradlew build` should always "just work". With the current setup the integration tests can only pull the latest version of the smithy dependencies (for example `smithy-model`) from the local maven repo. However, this means that if you pull the repo locally it can fail if you have old (or no) smithy dependencies in your local maven repo. This PR updates the behavior of the integration tests to pull the latest smithy dependencies from either maven local or maven central so the build will "just work" when you pull the latest version of the repo.

Note: Maven local is still preferred if newer or equal version numbers are available in the local maven repo.

#### Testing
- Tested that this worked when `.m2/repositories` (local maven repo) was fully deleted
- Tested that when an old, incompatible version of smithy-model (1.22.0) was used, build still picked up later deps and works


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
