### PR TITLE
Fix multi-project example and add integration test

### DIFF
--- a/examples/jar-plugin/multi-project/consumer/build.gradle.kts
+++ b/examples/jar-plugin/multi-project/consumer/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("software.amazon.smithy").version("0.7.0")
+    id("smithy-jar").version("0.7.0")
 }
 
 dependencies {

--- a/examples/jar-plugin/multi-project/producer1/src/main/java/software/amazon/smithy/producer1/Producer1Trait.java
+++ b/examples/jar-plugin/multi-project/producer1/src/main/java/software/amazon/smithy/producer1/Producer1Trait.java
@@ -1,21 +1,22 @@
 package software.amazon.smithy.producer1;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.traits.BooleanTrait;
+import software.amazon.smithy.model.traits.AnnotationTrait;
 
-public final class Producer1Trait extends BooleanTrait {
+public final class Producer1Trait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.producer#producer1");
 
-    public Producer1Trait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public Producer1Trait(ObjectNode objectNode) {
+        super(ID, objectNode);
     }
 
     public Producer1Trait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
-    public static final class Provider extends BooleanTrait.Provider<Producer1Trait> {
+    public static final class Provider extends AnnotationTrait.Provider<Producer1Trait> {
         public Provider() {
             super(ID, Producer1Trait::new);
         }

--- a/examples/jar-plugin/multi-project/producer2/src/main/java/software/amazon/smithy/producer2/Producer2Trait.java
+++ b/examples/jar-plugin/multi-project/producer2/src/main/java/software/amazon/smithy/producer2/Producer2Trait.java
@@ -1,21 +1,22 @@
 package software.amazon.smithy.producer2;
 
-import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
 import software.amazon.smithy.model.shapes.ShapeId;
-import software.amazon.smithy.model.traits.BooleanTrait;
+import software.amazon.smithy.model.traits.AnnotationTrait;
 
-public final class Producer2Trait extends BooleanTrait {
+public final class Producer2Trait extends AnnotationTrait {
     public static final ShapeId ID = ShapeId.from("smithy.producer#producer2");
 
-    public Producer2Trait(SourceLocation sourceLocation) {
-        super(ID, sourceLocation);
+    public Producer2Trait(ObjectNode objectNode) {
+        super(ID, objectNode);
     }
 
     public Producer2Trait() {
-        this(SourceLocation.NONE);
+        this(Node.objectNode());
     }
 
-    public static final class Provider extends BooleanTrait.Provider<Producer2Trait> {
+    public static final class Provider extends AnnotationTrait.Provider<Producer2Trait> {
         public Provider() {
             super(ID, Producer2Trait::new);
         }

--- a/examples/jar-plugin/multi-project/settings.gradle.kts
+++ b/examples/jar-plugin/multi-project/settings.gradle.kts
@@ -7,7 +7,7 @@ include(":consumer")
 pluginManagement {
     repositories {
         mavenLocal()
-         mavenCentral()
+        mavenCentral()
         // Uncomment these to use the published version of the plugin from your preferred source.
         // gradlePluginPortal()
     }

--- a/smithy-jar-plugin/src/it/java/software/amazon/smithy/gradle/MultiProjectTest.java
+++ b/smithy-jar-plugin/src/it/java/software/amazon/smithy/gradle/MultiProjectTest.java
@@ -1,0 +1,63 @@
+package software.amazon.smithy.gradle;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import static java.util.Objects.requireNonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class MultiProjectTest {
+    @Test
+    public void testProjection() {
+        Utils.withCopy("jar-plugin/multi-project", buildDir -> {
+            BuildResult result = GradleRunner.create()
+                    .forwardOutput()
+                    .withProjectDir(buildDir)
+                    .withArguments("clean", "build", "--stacktrace")
+                    .build();
+
+            // Check that expected smithy task executed for consumer
+            assertSame(requireNonNull(result.task(":consumer:smithyBuild")).getOutcome(), TaskOutcome.SUCCESS);
+            assertSame(requireNonNull(result.task(":consumer:smithyJarValidate")).getOutcome(), TaskOutcome.SUCCESS);
+
+            // Check that producer jars created
+            Utils.assertArtifactsCreated(buildDir,
+                    "producer1/build/libs/producer1-999.999.999.jar",
+                    "producer2/build/libs/producer2-999.999.999.jar");
+
+            // Check that all smithy and jar artifacts for consumer created
+            Utils.assertArtifactsCreated(buildDir,
+                    "consumer/build/smithyprojections/consumer/source/build-info/smithy-build-info.json",
+                    "consumer/build/smithyprojections/consumer/source/sources/main.smithy",
+                    "consumer/build/smithyprojections/consumer/source/sources/manifest",
+                    "consumer/build/libs/consumer-999.999.999.jar");
+
+            // Check that that jar contains correct objects
+            Utils.assertJarContains(buildDir, "consumer/build/libs/consumer-999.999.999.jar",
+                    "META-INF/MANIFEST.MF",
+                    "META-INF/smithy/manifest",
+                    "META-INF/smithy/main.smithy");
+
+            // Check that correct tags were added to jar manifest
+            JarFile jar = new JarFile(new File(buildDir, "consumer/build/libs/consumer-999.999.999.jar"));
+            Manifest manifest = jar.getManifest();
+            String tags = (String) manifest.getMainAttributes().get(new Attributes.Name("Smithy-Tags"));
+            jar.close();
+            String[] tagValues = tags.split(", ");
+
+            assertThat(Arrays.asList(tagValues), containsInAnyOrder(
+                    "software.amazon.smithy.it:consumer", "software.amazon.smithy.it:consumer:999.999.999",
+                    "software.amazon.smithy.it"));
+        });
+    }
+}


### PR DESCRIPTION
### Description of changes
Corrects the multi-project example to use the new `smithy-jar` plugin and the `AnnotationTrait` class instead of `BooleanTrait`. The previous version of the gradle-plugin did not have an integration test for the multi-project example, so this PR also adds an integration test for the jar plugin using the multi-project example. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
