### PR TITLE
Update javadocs

### DIFF
--- a/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/SmithyExtension.java
+++ b/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/SmithyExtension.java
@@ -31,7 +31,7 @@ import software.amazon.smithy.utils.IoUtils;
 
 
 /**
- * Gradle configuration settings for Smithy base plugin.
+ * Gradle configuration settings for Smithy plugins.
  */
 public abstract class SmithyExtension {
     private static final String SMITHY_BUILD_CONFIG_DEFAULT = "smithy-build.json";
@@ -78,7 +78,7 @@ public abstract class SmithyExtension {
     public abstract Property<Boolean> getFormat();
 
     /**
-     * Gets a custom collection of smithy-build.json files to use when
+     * Gets a collection of smithy-build.json files to use when
      * building the model.
      *
      * @return Returns the collection of build configurations.
@@ -163,6 +163,16 @@ public abstract class SmithyExtension {
                 .map(file -> SmithyUtils.getProjectionPluginPath(file, projection, plugin));
     }
 
+    /**
+     * Gets the default directory to write smithy outputs to.
+     *
+     * <p>If an output directory is defined in the smithy-build.json then that is
+     * used. Otherwise, a smithyprojections output directory under the default gradle
+     * build directory is used.
+     *
+     * @param project gradle project
+     * @return provider that returns the default output directory
+     */
     @Internal
     private Provider<Directory> getDefaultOutputDirectory(final Project project) {
         return getSmithyBuildConfigs()

--- a/smithy-jar-plugin/src/main/java/software/amazon/smithy/gradle/actions/SmithyManifestUpdateAction.java
+++ b/smithy-jar-plugin/src/main/java/software/amazon/smithy/gradle/actions/SmithyManifestUpdateAction.java
@@ -22,7 +22,9 @@ import software.amazon.smithy.gradle.SmithyGradleVersion;
 /**
  * Action that updates a JAR's manifest with Smithy-specific attributes.
  *
- * <p>This action adds projection tags to JAR manifest via the {@code SmithyTags} property
+ * <p>This action adds projection tags to JAR manifest via the {@code SmithyTags} property.
+ * A number of headers are also included in the manifest to add basic build info such as
+ * JDK version used for the build and the build timestamp.
  */
 public final class SmithyManifestUpdateAction implements Action<Task> {
     private static final String BUILD_TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";


### PR DESCRIPTION
### Description of changes
Touches up javadocs for the `smithy-jar` and `smithy-base` plugins.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
