### PR TITLE
Add namespace to plugin ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This plugin can be applied to a project as follows:
 ```kotlin 
 // build.gradle.kts
 plugins {
-    id("smithy-base").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-base").version("0.8.0")
 }
 ```
 However, no tasks will be created unless.
@@ -72,7 +72,7 @@ The `smithy-jar` plugin must be used with another plugin that creates a `jar` ta
 // build.gradle.kts
 plugins {
     id("java-library") // creates jar task
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 ```
 

--- a/bin/sync-version.sh
+++ b/bin/sync-version.sh
@@ -4,8 +4,8 @@ EXPECTED_VERSION=$(cat VERSION)
 
 # find all gradle build files and replace the existing version with the expected
 find . -type f -name 'build.gradle.kts' \
-  -exec sed -i '' "s/\(id(\"smithy-\([[:lower:]]*\)\")\.version(\"\)\([[:digit:]\.]*\)\")/\\1${EXPECTED_VERSION}\")/" {} \;
+  -exec sed -i '' "s/\(id(\"software\.amazon\.smithy\.gradle\.smithy-\([[:lower:]]*\)\")\.version(\"\)\([[:digit:]\.]*\)\")/\\1${EXPECTED_VERSION}\")/" {} \;
 
 # update all references to the version in READMEs
 find . -type f -name 'README.md' \
-  -exec sed -i '' "s/\(id(\"smithy-\([[:lower:]]*\)\")\.version(\"\)\([[:digit:]\.]*\)\")/\\1${EXPECTED_VERSION}\")/" {} \;
+  -exec sed -i '' "s/\(id(\"software\.amazon\.smithy\.gradle\.smithy-\([[:lower:]]*\)\")\.version(\"\)\([[:digit:]\.]*\)\")/\\1${EXPECTED_VERSION}\")/" {} \;

--- a/examples/base-plugin/failure-cases/conflicting-output-dir-configs/build.gradle.kts
+++ b/examples/base-plugin/failure-cases/conflicting-output-dir-configs/build.gradle.kts
@@ -3,7 +3,7 @@
 
 plugins {
     `java-library`
-    id("smithy-base").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-base").version("0.8.0")
 }
 
 repositories {

--- a/examples/base-plugin/failure-cases/forbid-dependency-resolution-fork/build.gradle.kts
+++ b/examples/base-plugin/failure-cases/forbid-dependency-resolution-fork/build.gradle.kts
@@ -4,7 +4,7 @@
 
 plugins {
     `java-library`
-    id("smithy-base").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-base").version("0.8.0")
 }
 
 repositories {

--- a/examples/base-plugin/failure-cases/forbid-dependency-resolution-no-fork/build.gradle.kts
+++ b/examples/base-plugin/failure-cases/forbid-dependency-resolution-no-fork/build.gradle.kts
@@ -3,7 +3,7 @@
 
 plugins {
     `java-library`
-    id("smithy-base").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-base").version("0.8.0")
 }
 
 repositories {

--- a/examples/base-plugin/includes-in-sourceset/build.gradle.kts
+++ b/examples/base-plugin/includes-in-sourceset/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-base").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-base").version("0.8.0")
 }
 
 sourceSets {

--- a/examples/base-plugin/output-directory-config/build.gradle.kts
+++ b/examples/base-plugin/output-directory-config/build.gradle.kts
@@ -4,7 +4,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-base").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-base").version("0.8.0")
 }
 
 repositories {

--- a/examples/base-plugin/output-directory-with-projection/build.gradle.kts
+++ b/examples/base-plugin/output-directory-with-projection/build.gradle.kts
@@ -3,7 +3,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-base").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-base").version("0.8.0")
 }
 
 

--- a/examples/base-plugin/output-directory/build.gradle.kts
+++ b/examples/base-plugin/output-directory/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-base").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-base").version("0.8.0")
 }
 
 repositories {

--- a/examples/base-plugin/scans-for-cli-version/build.gradle.kts
+++ b/examples/base-plugin/scans-for-cli-version/build.gradle.kts
@@ -3,7 +3,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-base").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-base").version("0.8.0")
 }
 
 repositories {

--- a/examples/base-plugin/smithy-build-task/build.gradle.kts
+++ b/examples/base-plugin/smithy-build-task/build.gradle.kts
@@ -7,7 +7,7 @@ import software.amazon.smithy.gradle.tasks.SmithyBuildTask
 
 plugins {
     id("java-library")
-    id("smithy-base").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-base").version("0.8.0")
 }
 
 tasks["jar"].enabled = false

--- a/examples/jar-plugin/adds-tags/build.gradle.kts
+++ b/examples/jar-plugin/adds-tags/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 group = "software.amazon.smithy"

--- a/examples/jar-plugin/build-dependencies/internal-model/build.gradle.kts
+++ b/examples/jar-plugin/build-dependencies/internal-model/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     `java-library`
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 repositories {

--- a/examples/jar-plugin/build-dependencies/service/build.gradle.kts
+++ b/examples/jar-plugin/build-dependencies/service/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     `java-library`
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 repositories {

--- a/examples/jar-plugin/custom-trait/consumer/build.gradle.kts
+++ b/examples/jar-plugin/custom-trait/consumer/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java-library")
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 

--- a/examples/jar-plugin/custom-trait/custom-string-trait/build.gradle.kts
+++ b/examples/jar-plugin/custom-trait/custom-string-trait/build.gradle.kts
@@ -1,7 +1,7 @@
 // This package defines a custom trait for use in other models
 plugins {
     id("java-library")
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 repositories {

--- a/examples/jar-plugin/disable-jar/build.gradle.kts
+++ b/examples/jar-plugin/disable-jar/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 repositories {

--- a/examples/jar-plugin/failure-cases/invalid-projection/build.gradle.kts
+++ b/examples/jar-plugin/failure-cases/invalid-projection/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 repositories {

--- a/examples/jar-plugin/failure-cases/missing-runtime-dependency/build.gradle.kts
+++ b/examples/jar-plugin/failure-cases/missing-runtime-dependency/build.gradle.kts
@@ -5,7 +5,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 repositories {

--- a/examples/jar-plugin/failure-cases/require-prerequisite-plugin/build.gradle.kts
+++ b/examples/jar-plugin/failure-cases/require-prerequisite-plugin/build.gradle.kts
@@ -2,7 +2,7 @@
 // prerequisite plugin. The build will fail.
 
 plugins {
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy-jar").version("0.8.0")
 }
 
 repositories {

--- a/examples/jar-plugin/kotlin-jvm-project/build.gradle.kts
+++ b/examples/jar-plugin/kotlin-jvm-project/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     kotlin("jvm") version "1.9.0"
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 repositories {

--- a/examples/jar-plugin/multi-project/consumer/build.gradle.kts
+++ b/examples/jar-plugin/multi-project/consumer/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 dependencies {

--- a/examples/jar-plugin/multiple-jars/build.gradle.kts
+++ b/examples/jar-plugin/multiple-jars/build.gradle.kts
@@ -7,7 +7,7 @@ import software.amazon.smithy.gradle.tasks.SmithyJarStagingTask
 
 plugins {
     `java-library`
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 val buildTask: SmithyBuildTask = tasks.getByName<SmithyBuildTask>("smithyBuild")

--- a/examples/jar-plugin/multiple-sources/build.gradle.kts
+++ b/examples/jar-plugin/multiple-sources/build.gradle.kts
@@ -5,7 +5,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 repositories {

--- a/examples/jar-plugin/no-models/build.gradle.kts
+++ b/examples/jar-plugin/no-models/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 group = "software.amazon.smithy"

--- a/examples/jar-plugin/projection/build.gradle.kts
+++ b/examples/jar-plugin/projection/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 repositories {

--- a/examples/jar-plugin/projects-with-tags/build.gradle.kts
+++ b/examples/jar-plugin/projects-with-tags/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 repositories {

--- a/examples/jar-plugin/source-projection/build.gradle.kts
+++ b/examples/jar-plugin/source-projection/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     id("java-library")
-    id("smithy-jar").version("0.8.0")
+    id("software.amazon.smithy.gradle.smithy-jar").version("0.8.0")
 }
 
 repositories {

--- a/smithy-base-plugin/build.gradle.kts
+++ b/smithy-base-plugin/build.gradle.kts
@@ -8,7 +8,7 @@ description = "This plugin sets up the basic capabilities necessary for building
 gradlePlugin {
     plugins {
         create("smithy-base-plugin") {
-            id = "smithy-base"
+            id = "software.amazon.smithy.gradle.smithy-base"
             displayName = "Smithy Gradle Base Plugin"
             description = description
             implementationClass = "software.amazon.smithy.gradle.SmithyBasePlugin"

--- a/smithy-jar-plugin/build.gradle.kts
+++ b/smithy-jar-plugin/build.gradle.kts
@@ -5,7 +5,7 @@ description = ""
 gradlePlugin {
     plugins {
         create("smithy-jar-plugin") {
-            id = "smithy-jar"
+            id = "software.amazon.smithy.gradle.smithy-jar"
             displayName = "Smithy Gradle Jar Packaging Plugin"
             description = description
             implementationClass = "software.amazon.smithy.gradle.SmithyJarPlugin"


### PR DESCRIPTION
### Description of changes
Gradle requires plugins ID's to be namespaced. 
This PR updates the plugin ids to use the `software.amazon.smithy.gradle` namespace.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
