### PR TITLE
Update task ordering

### DIFF
--- a/smithy-jar-plugin/src/main/java/software/amazon/smithy/gradle/SmithyJarPlugin.java
+++ b/smithy-jar-plugin/src/main/java/software/amazon/smithy/gradle/SmithyJarPlugin.java
@@ -39,7 +39,7 @@ public class SmithyJarPlugin implements Plugin<Project> {
             "org.jetbrains.kotlin.jvm",
             "org.jetbrains.kotlin.android"
     );
-    private static final List<String> SUPPORTED_LANGUAGES = ListUtils.of("java", "kotlin");
+    private static final List<String> SUPPORTED_LANGUAGES = ListUtils.of("java", "kotlin", "scala");
     private boolean wasApplied = false;
     private SmithyExtension extension;
 


### PR DESCRIPTION
### Description of changes 
Updates the ordering of tasks so that: 
1. The Format task executes before the build task. This ensures any files written to an output jar will be formatted. 
2. Updates to create a dependency for the compile task on `processResources`. This ensures that smithy output files are in the META-INF/ output folder before the compile task is executed so they are available to the compile task for any annotation processors.

The following is an example of the new task order for the `quickstart gradle` template (using --dry-run)
```
:smithyFormat SKIPPED
:smithyBuild SKIPPED
:smithyJarStaging SKIPPED
:processResources SKIPPED
:compileJava SKIPPED
:classes SKIPPED
:jar SKIPPED
:assemble SKIPPED
:compileTestJava SKIPPED
:smithyJarValidate SKIPPED
:processTestResources SKIPPED
:testClasses SKIPPED
:test SKIPPED
:check SKIPPED
:build SKIPPED
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
