### PR TITLE
Update to use correct parsing method to handle comments in build json

### DIFF
--- a/examples/base-plugin/smithy-build-task/smithy-build.json
+++ b/examples/base-plugin/smithy-build-task/smithy-build.json
@@ -1,3 +1,4 @@
 {
+  // A comment.
   "version": "1.0"
 }

--- a/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/SmithyExtension.java
+++ b/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/SmithyExtension.java
@@ -204,7 +204,7 @@ public abstract class SmithyExtension {
         if (!Files.exists(buildConfigPath)) {
             return Optional.empty();
         }
-        return Node.parse(IoUtils.readUtf8File(buildConfigPath))
+        return Node.parseJsonWithComments(IoUtils.readUtf8File(buildConfigPath))
                 .expectObjectNode()
                 .getMember(OUTPUT_DIRECTORY)
                 .map(Node::expectStringNode)


### PR DESCRIPTION
Issue #, if available:

Fixes #108

*Description of changes:*
Updates to use the `.parseJsonWithComments` method to correctly handle comments in `smithy-build.json` files. Also adds a comment to a build file in the integration tests to prevent regressions. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
