### PR TITLE
Update to use InputFiles for build config parameter

### DIFF
--- a/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildTask.java
+++ b/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildTask.java
@@ -16,6 +16,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
@@ -61,7 +62,7 @@ public abstract class SmithyBuildTask extends AbstractSmithyCliTask {
      *
      * @return list of smithy-build config json files
      */
-    @Input
+    @InputFiles
     public abstract Property<FileCollection> getSmithyBuildConfigs();
 
 


### PR DESCRIPTION
Issue #, if available: https://github.com/smithy-lang/smithy-gradle-plugin/issues/109

*Description of changes:*
Updates the config file parameter to use `InputFiles` instead of `Input` to ensure changes to build configs trigger incremental build.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
