### PR TITLE
Move smithyCli configuration and correct issue with conventions

### DIFF
--- a/examples/base-plugin/smithy-build-task/build.gradle.kts
+++ b/examples/base-plugin/smithy-build-task/build.gradle.kts
@@ -6,12 +6,8 @@ import software.amazon.smithy.gradle.tasks.SmithyBuildTask
 // and the classpath used when building.
 
 plugins {
-    id("java-library")
     id("software.amazon.smithy.gradle.smithy-base").version("0.9.0")
 }
-
-tasks["jar"].enabled = false
-tasks["smithyBuild"].enabled = false
 
 tasks.create<SmithyBuildTask>("doit") {
     models.set(files("model/"))

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/SmithyBuildTaskTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/SmithyBuildTaskTest.java
@@ -30,7 +30,6 @@ public class SmithyBuildTaskTest {
                     .withProjectDir(buildDir)
                     .withArguments("build", "--stacktrace")
                     .build();
-
             Utils.assertSmithyBuildDidNotRun(result);
             Utils.assertArtifactsCreated(
                     buildDir,

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
@@ -47,16 +47,6 @@ public final class SmithyUtils {
     private SmithyUtils() {}
 
     /**
-     * Gets the {@code SmithyExtension} extension of a {@code Project}.
-     *
-     * @param project Project to query.
-     * @return Returns the extension.
-     */
-    public static SmithyExtension getSmithyExtension(Project project) {
-        return project.getExtensions().getByType(SmithyExtension.class);
-    }
-
-    /**
      * Gets the path to a projection plugins output.
      *
      * @param smithyOutputDirectory output directory to get plugin path from
@@ -236,10 +226,6 @@ public final class SmithyUtils {
         }
     }
 
-    static String getSmithyCliConfigurationName(SourceSet sourceSet) {
-        return getRelativeSourceSetName(sourceSet, SMITHY_CLI_CONFIGURATION_NAME);
-    }
-
     static String getSmithyBuildConfigurationName(SourceSet sourceSet) {
         return getRelativeSourceSetName(sourceSet, SMITHY_BUILD_CONFIGURATION_NAME);
 
@@ -249,8 +235,8 @@ public final class SmithyUtils {
         return SourceSet.isMain(sourceSet) ? name : sourceSet.getName() + StringUtils.capitalize(name);
     }
 
-    public static Configuration getCliConfiguration(Project project, SourceSet sourceSet) {
-        return project.getConfigurations().getByName(getSmithyCliConfigurationName(sourceSet));
+    public static Configuration getCliConfiguration(Project project) {
+        return project.getConfigurations().getByName(SMITHY_CLI_CONFIGURATION_NAME);
     }
 }
 

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/internal/CliDependencyResolver.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/internal/CliDependencyResolver.java
@@ -45,7 +45,6 @@ public final class CliDependencyResolver {
      * detected is used for the CLI.
      *
      * @param project Project to add dependencies to.
-     * @param sourceSet sourceset to use to find configurations.
      *
      * @return version of the cli that was resolved.
      */

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/AbstractSmithyCliTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/AbstractSmithyCliTask.java
@@ -55,15 +55,14 @@ abstract class AbstractSmithyCliTask extends BaseSmithyTask {
     final void executeCliProcess(String command,
                                  List<String> additionalArgs,
                                  FileCollection sources,
-                                 FileCollection modelDiscoveryClasspath,
                                  boolean disableModelDiscovery
     ) {
         List<String> args = new ArrayList<>();
         args.add(command);
 
-        if (modelDiscoveryClasspath != null) {
+        if (!getModelDiscoveryClasspath().get().isEmpty()) {
             args.add("--discover-classpath");
-            args.add(modelDiscoveryClasspath.getAsPath());
+            args.add(getModelDiscoveryClasspath().get().getAsPath());
         } else if (!disableModelDiscovery) {
             args.add("--discover");
         }

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/BaseSmithyTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/BaseSmithyTask.java
@@ -35,7 +35,7 @@ abstract class BaseSmithyTask extends DefaultTask {
         getFork().convention(false);
         getShowStackTrace().convention(ShowStacktrace.INTERNAL_EXCEPTIONS);
 
-        // By default, there are no build dependencies or models discovery
+        // By default, the build classpath and model discovery classpaths are empty file collections.
         getBuildClasspath().set(getProject().files());
         getModelDiscoveryClasspath().set(getProject().files());
 

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildTask.java
@@ -40,7 +40,6 @@ public abstract class SmithyBuildTask extends AbstractSmithyCliTask {
         getOutputDir().convention(SmithyUtils.getProjectionOutputDirProperty(getProject()));
     }
 
-
     /**
      * Tags that are searched for in classpaths when determining which
      * models are projected into the created JAR.
@@ -112,7 +111,7 @@ public abstract class SmithyBuildTask extends AbstractSmithyCliTask {
         BuildParameterBuilder builder = new BuildParameterBuilder();
 
         // Model discovery classpath
-        builder.libClasspath(getRuntimeClasspath().get().getAsPath());
+        builder.libClasspath(getModelDiscoveryClasspath().get().getAsPath());
         builder.buildClasspath(getCliExecutionClasspath().get().getAsPath());
         builder.projectionSourceTags(getProjectionSourceTags().get());
         builder.allowUnknownTraits(getAllowUnknownTraits().get());

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyFormatTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyFormatTask.java
@@ -41,7 +41,6 @@ public abstract class SmithyFormatTask extends AbstractSmithyCliTask {
                 executeCliProcess("format",
                         ListUtils.of(),
                         objectFactory.fileCollection().from(file),
-                        null,
                         true
                 );
             }

--- a/smithy-jar/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
+++ b/smithy-jar/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
@@ -10,7 +10,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -36,7 +35,6 @@ public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
         super(objectFactory);
         getAllowUnknownTraits().convention(false);
         getDisableModelDiscovery().convention(false);
-        getResolvedCliClasspath().convention(getProject().getConfigurations().getByName("smithyCli"));
         setDescription(DESCRIPTION);
     }
 
@@ -56,15 +54,6 @@ public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
      */
     @InputFiles
     public abstract Property<FileCollection> getJarToValidate();
-
-    /**
-     * Classpath used for discovery of additional Smithy models during cli execution.
-     *
-     * <p>Defaults to an empty collection.
-     */
-    @Classpath
-    @Optional
-    public abstract Property<FileCollection> getModelDiscoveryClasspath();
 
     /**
      * Disable model discovery.
@@ -90,7 +79,7 @@ public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
     @Internal
     @Override
     Provider<FileCollection> getCliExecutionClasspath() {
-        return getResolvedCliClasspath();
+        return getCliClasspath();
     }
 
     @TaskAction
@@ -100,7 +89,6 @@ public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
         // Set models to an empty collection so source models are not included in validation path.
         executeCliProcess("validate", ListUtils.of(),
                 getJarToValidate().get(),
-                getModelDiscoveryClasspath().getOrNull(),
                 getDisableModelDiscovery().get()
         );
     }


### PR DESCRIPTION
*Description of changes:*
1. Corrects an issue where the conventions set for the smithyBuildtask were causing custom defined tasks used without the java plugin applied to fail. The failure was due to the conventions not lazily executing the pulling of the configurations used for each of the classpaths. 

2. As part of fixing the above it was nicer to move the smithyCli config to always be created whenever the base plugin is applied even if no source sets are created. This allows users to apply the base plugin to resolve the cli artifact without needing to pass in a custom classpath with the CLI on it to the build task.

3. Applies some simple cleanup and renames the "RuntimeClasspath" parameter to "ModelDiscoveryClasspath" parameter for clarity for users using the build task on its own.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
