### PR TITLE
Update to allow for resolution when file does not exist yet

### DIFF
--- a/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
+++ b/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
@@ -65,7 +65,7 @@ public final class SmithyUtils {
      * @return Returns the resolved path.
      */
     public static Path getProjectionPluginPath(File smithyOutputDirectory, String projection, String plugin) {
-        if (!smithyOutputDirectory.isDirectory()) {
+        if (smithyOutputDirectory.exists() && !smithyOutputDirectory.isDirectory()) {
             throw new RuntimeException("Expected directory for outputDir but found file");
         }
         return smithyOutputDirectory.toPath()


### PR DESCRIPTION
*Issue #, if available:* issue #113

*Description of changes:*
Updates guard within `getProjectionPluginPath` utility function to allow for path resolution when file does not yet exist. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
