### PR TITLE
Update javadocs and reduce noise from doclint warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,11 @@ subprojects {
         useJUnitPlatform()
     }
 
+    // Suppress warnings in javadocs
+    tasks.withType<Javadoc> {
+        (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:-html", "-quiet")
+    }
+
     apply(plugin = "com.adarshr.test-logger")
 
     configure<TestLoggerExtension> {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -22,7 +22,7 @@
     <!-- Files must contain a copyright header, with or without a year. -->
     <module name="RegexpHeader">
         <property name="header"
-                  value="/\*\n \* Copyright( 20(19|21)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
+                  value="/\*\n \* Copyright( 20(19|20|21|22|23)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
         <property name="fileExtensions" value="java"/>
     </module>
 
@@ -70,7 +70,7 @@
         <module name="JavadocMethod">
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowedAnnotations" value="Override, Test, TaskAction"/>
         </module>
         <module name="JavadocStyle"/>
         <module name="NonEmptyAtclauseDescription"/>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -22,7 +22,7 @@
     <!-- Files must contain a copyright header, with or without a year. -->
     <module name="RegexpHeader">
         <property name="header"
-                  value="/\*\n \* Copyright( 20(19|20|21|22|23)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
+                  value="/\*\n \* Copyright( 20(19|20|21|22|23|24)|) Amazon\.com, Inc\. or its affiliates\. All Rights Reserved\.\n"/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/SmithyBasePlugin.java
+++ b/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/SmithyBasePlugin.java
@@ -26,6 +26,9 @@ import software.amazon.smithy.gradle.tasks.SmithyFormatTask;
  * A {@link org.gradle.api.Plugin} that builds and validates Smithy models.
  */
 public final class SmithyBasePlugin implements Plugin<Project> {
+    /**
+     * Default name to use for the build task created by this plugin.
+     */
     public static final String SMITHY_BUILD_TASK_NAME = "smithyBuild";
 
     private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("8.2.0");

--- a/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/internal/CliDependencyResolver.java
+++ b/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/internal/CliDependencyResolver.java
@@ -44,7 +44,9 @@ public final class CliDependencyResolver {
      * detected is used for the CLI.
      *
      * @param project Project to add dependencies to.
+     * @param sourceSet sourceset to use to find configurations.
      *
+     * @return version of the cli that was resolved.
      */
     public static String resolve(Project project, SourceSet sourceSet) {
         Configuration cli = SmithyUtils.getCliConfiguration(project, sourceSet);

--- a/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/tasks/AbstractSmithyCliTask.java
+++ b/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/tasks/AbstractSmithyCliTask.java
@@ -22,6 +22,9 @@ import software.amazon.smithy.gradle.SmithyUtils;
 @DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
 abstract class AbstractSmithyCliTask extends BaseSmithyTask {
 
+    /**
+     * Object factory used to create new gradle domain objects such as {@code FileCollection}s.
+     */
     protected final ObjectFactory objectFactory;
 
     AbstractSmithyCliTask(ObjectFactory objectFactory) {

--- a/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/tasks/BaseSmithyTask.java
+++ b/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/tasks/BaseSmithyTask.java
@@ -29,7 +29,8 @@ import org.gradle.workers.WorkerExecutor;
  */
 @DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
 abstract class BaseSmithyTask extends DefaultTask {
-    protected final StartParameter startParameter;
+
+    private final StartParameter startParameter;
 
     BaseSmithyTask() {
         getFork().convention(false);
@@ -62,10 +63,11 @@ abstract class BaseSmithyTask extends DefaultTask {
     @Optional
     public abstract Property<FileCollection> getRuntimeClasspath();
 
-    /** Read-only property that returns the classpath used to determine the
+    /**
+     * Read-only property that returns the classpath used to determine the
      * classpath used when executing the cli.
      *
-     * @return classpath to use when executing cli command
+     * @return classpath to use when executing cli command.
      */
     @Internal
     Provider<FileCollection> getCliExecutionClasspath() {
@@ -96,7 +98,7 @@ abstract class BaseSmithyTask extends DefaultTask {
      *
      * <p> Defaults to {@code false}
      *
-     * @return flag indicating fork setting
+     * @return flag indicating fork setting.
      */
     @Input
     @Optional
@@ -107,7 +109,7 @@ abstract class BaseSmithyTask extends DefaultTask {
      *
      * <p> Defaults to {@code ShowStacktrace.INTERNAL_EXCEPTIONS}
      *
-     * @return stack trace setting
+     * @return stack trace setting.
      */
     @Input
     @Optional
@@ -120,6 +122,11 @@ abstract class BaseSmithyTask extends DefaultTask {
     }
 
 
+    /**
+     * Writes header-formatted text to the build output.
+     *
+     * @param text text to write as a header.
+     */
     protected void writeHeading(String text) {
         StyledTextOutput output = getServices().get(StyledTextOutputFactory.class)
                 .create("smithy")

--- a/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildTask.java
+++ b/smithy-base-plugin/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildTask.java
@@ -66,11 +66,12 @@ public abstract class SmithyBuildTask extends AbstractSmithyCliTask {
     public abstract Property<FileCollection> getSmithyBuildConfigs();
 
 
-    /** Sets whether to fail a {@link SmithyBuildTask} if an unknown trait is encountered.
+    /**
+     * Sets whether to fail a {@link SmithyBuildTask} if an unknown trait is encountered.
      *
-     * <p> Defaults to {@code true}
+     * <p> Defaults to {@code true}.
      *
-     * @return flag indicating state of allowUnknownTraits setting
+     * @return flag indicating state of allowUnknownTraits setting.
      */
     @Input
     @Optional
@@ -92,7 +93,8 @@ public abstract class SmithyBuildTask extends AbstractSmithyCliTask {
     @Optional
     public abstract DirectoryProperty getOutputDir();
 
-    /** Read-only property.
+    /**
+     * Read-only property.
      *
      * @return list of absolute paths of model files.
      */


### PR DESCRIPTION
*Description of changes:*
Silences the xdoclint warnings to reduce the amount of noise and updates a few javadoc comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
