### PR TITLE
Turn on closing and releasing of repository with jreleaser

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,8 +66,8 @@ jreleaser {
                     active = Active.ALWAYS
                     url = "https://aws.oss.sonatype.org/service/local"
                     snapshotUrl = "https://aws.oss.sonatype.org/content/repositories/snapshots"
-                    closeRepository.set(false)
-                    releaseRepository.set(false)
+                    closeRepository.set(true)
+                    releaseRepository.set(true)
                     stagingRepositories.add("${rootProject.buildDir}/staging")
                 }
             }


### PR DESCRIPTION
### Background
* Updates the gradle build to enable the use of Jreleaser for closing and releasing the repository

### Testing
* The last release used jreleaser for staging with nexus.
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
