### PR TITLE
Add severity option for validators

### DIFF
--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/BaseSmithyTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/BaseSmithyTask.java
@@ -127,6 +127,16 @@ abstract class BaseSmithyTask extends DefaultTask {
     @Optional
     public abstract Property<ShowStacktrace> getShowStackTrace();
 
+    /**
+     * Set the minimum reported validation severity.
+     *
+     * <p>This value should be one of: NOTE, WARNING [default], DANGER, ERROR.
+     *
+     * @return minimum validator severity
+     */
+    @Input
+    @Optional
+    public abstract Property<String> getSeverity();
 
     @Internal
     WorkerExecutor getExecutor() {

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildTask.java
@@ -25,6 +25,7 @@ import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import software.amazon.smithy.cli.BuildParameterBuilder;
 import software.amazon.smithy.gradle.SmithyUtils;
+import software.amazon.smithy.model.validation.Severity;
 
 /**
  * Executes the Smithy CLI {@code build} command.
@@ -39,6 +40,7 @@ public abstract class SmithyBuildTask extends AbstractSmithyCliTask {
         super(objectFactory);
 
         getSourceProjection().convention("source");
+        getSeverity().convention(Severity.WARNING.toString());
         getOutputDir().convention(SmithyUtils.getProjectionOutputDirProperty(getProject()));
     }
 
@@ -149,6 +151,11 @@ public abstract class SmithyBuildTask extends AbstractSmithyCliTask {
         // Add extra configuration options for build command
         List<String> extraArgs = new ArrayList<>();
         configureLoggingOptions(extraArgs);
+
+        // Add validator severity option if it exists
+        extraArgs.add("--severity");
+        extraArgs.add(getSeverity().get());
+
         builder.addExtraArgs(extraArgs.toArray(new String[0]));
 
         BuildParameterBuilder.Result result = builder.build();

--- a/smithy-jar/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
+++ b/smithy-jar/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
@@ -18,7 +18,6 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import software.amazon.smithy.model.validation.Severity;
-import software.amazon.smithy.utils.ListUtils;
 
 
 /**

--- a/smithy-jar/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
+++ b/smithy-jar/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.gradle.tasks;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.inject.Inject;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.model.ObjectFactory;
@@ -15,6 +17,7 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
+import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.utils.ListUtils;
 
 
@@ -35,6 +38,7 @@ public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
         super(objectFactory);
         getAllowUnknownTraits().convention(false);
         getDisableModelDiscovery().convention(false);
+        getSeverity().convention(Severity.ERROR.toString());
         setDescription(DESCRIPTION);
     }
 
@@ -68,6 +72,17 @@ public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
     public abstract Property<Boolean> getDisableModelDiscovery();
 
     /**
+     * Set the minimum reported validation severity.
+     *
+     * <p>This value should be one of: NOTE, WARNING, DANGER, ERROR [default].
+     *
+     * @return minimum validator severity
+     */
+    @Input
+    @Optional
+    public abstract Property<String> getSeverity();
+
+    /**
      * Gets the classpath to use when executing the Smithy CLI.
      *
      * <p>The cli execution classpath for this task is different from other build
@@ -86,8 +101,13 @@ public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
     public void execute() {
         writeHeading("Running smithy validate");
 
+        // Add validator severity settings
+        List<String> extraArgs = new ArrayList<>();
+        extraArgs.add("--severity");
+        extraArgs.add(getSeverity().get());
+
         // Set models to an empty collection so source models are not included in validation path.
-        executeCliProcess("validate", ListUtils.of(),
+        executeCliProcess("validate", extraArgs,
                 getJarToValidate().get(),
                 getDisableModelDiscovery().get()
         );


### PR DESCRIPTION
#### Background
Adds a property to set the severity of validators for the `validate` and `build` tasks.

The default severity for the build task remains `WARNING` while the default for the `jarValidate` task is updated to `ERROR`. This prevents the double-printing of warning events during the build so that by default the jarValidate task only prints validation events that would have caused it to fail.

Note: not all smithy-cli commands have a `severity` option.

#### Testing
Executed a build with and without this change and confirmed the 

```
> Task :service:smithyFormat
Running smithy format

> Task :service:smithyBuild
Running smithy build

──  WARNING  ──────────────────────────────────────────────────────────── DocUrl
Shape: com.example.cafe.service#Order
File:  /Users/hpm/smithy-gradle-tutorial/service/model/service.smithy:25:1

24| @externalDocumentation(wikipedia: "https://en.wikipedia.org/wiki/Order")
25| resource Order {
  | ^

External url `https://en.wikipedia.org/wiki/Order` is invalid.


──  WARNING  ────────────────────────── HttpMethodSemantics.MissingReadonlyTrait
Shape: com.example.cafe.common#dummy
File:  /Users/hpm/smithy-gradle-tutorial/lib/build/libs/lib.jar!/META-INF/smithy/common.smithy:25:1

25| @http(code: 200, method: "GET", uri: "/yay")
  | ^
26| operation dummy {}

This operation uses the `GET` method in the `http` trait, but is not marked with
the readonly trait

SUCCESS: Validated 234 shapes (WARNING: 2)

Validated model, now starting projections...

──  source  ────────────────────────────────────────────────────────────────────
Completed projection source (234): /Users/hpm/smithy-gradle-tutorial/service/build/smithyprojections/service/source

Summary: Smithy built 1 projection(s), 3 plugin(s), and 4 artifacts

> Task :service:smithyJarValidate
Running smithy validate

──  WARNING  ────────────────────────── HttpMethodSemantics.MissingReadonlyTrait
Shape: com.example.cafe.common#dummy
File:  /Users/hpm/smithy-gradle-tutorial/lib/build/libs/lib.jar!/META-INF/smithy/common.smithy:25:1

25| @http(code: 200, method: "GET", uri: "/yay")
  | ^
26| operation dummy {}

This operation uses the `GET` method in the `http` trait, but is not marked with
the readonly trait


──  WARNING  ──────────────────────────────────────────────────────────── DocUrl
Shape: com.example.cafe.service#Order
File:  /Users/hpm/smithy-gradle-tutorial/service/build/libs/service.jar!/META-INF/smithy/service.smithy:25:1

24| @externalDocumentation(wikipedia: "https://en.wikipedia.org/wiki/Order")
25| resource Order {
  | ^

External url `https://en.wikipedia.org/wiki/Order` is invalid.

SUCCESS: Validated 234 shapes (WARNING: 2)


BUILD SUCCESSFUL in 4s
17 actionable tasks: 17 executed
```

After this change: 
```
> Task :service:smithyFormat
Running smithy format

> Task :service:smithyBuild
Running smithy build

──  WARNING  ──────────────────────────────────────────────────────────── DocUrl
Shape: com.example.cafe.service#Order
File:  /Users/hpm/smithy-gradle-tutorial/service/model/service.smithy:25:1

24| @externalDocumentation(wikipedia: "https://en.wikipedia.org/wiki/Order")
25| resource Order {
  | ^

External url `https://en.wikipedia.org/wiki/Order` is invalid.


──  WARNING  ────────────────────────── HttpMethodSemantics.MissingReadonlyTrait
Shape: com.example.cafe.common#dummy
File:  /Users/hpm/smithy-gradle-tutorial/lib/build/libs/lib.jar!/META-INF/smithy/common.smithy:25:1

25| @http(code: 200, method: "GET", uri: "/yay")
  | ^
26| operation dummy {}

This operation uses the `GET` method in the `http` trait, but is not marked with
the readonly trait

SUCCESS: Validated 234 shapes (WARNING: 2)

Validated model, now starting projections...

──  source  ────────────────────────────────────────────────────────────────────
Completed projection source (234): /Users/hpm/smithy-gradle-tutorial/service/build/smithyprojections/service/source

Summary: Smithy built 1 projection(s), 3 plugin(s), and 4 artifacts

> Task :service:smithyJarValidate
Running smithy validate
SUCCESS: Validated 234 shapes (WARNING: 2)


BUILD SUCCESSFUL in 15s
17 actionable tasks: 17 executed
````

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
