### PR TITLE
Add quiet option when gradle quiet flag set

### DIFF
--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/BaseSmithyTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/BaseSmithyTask.java
@@ -167,6 +167,7 @@ abstract class BaseSmithyTask extends DefaultTask {
             case QUIET:
                 args.add("--logging");
                 args.add(Level.OFF.toString());
+                args.add("--quiet");
                 break;
             case ERROR:
                 args.add("--logging");


### PR DESCRIPTION
#### Background
* Currently if the gradle `--quiet` option is set then the gradle build and validate tasks will still print validation events that are non-breaking. 
* This PR updates the `quiet` setting in the gradle plugins to use apply the `--quiet` flag to the CLI command so that non-breaking validation events are not printed

#### Testing
* Executed `gradle build --quiet` with examples and confirmed no validation events were printed to build logs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
