### PR TITLE
Move validate task to base plugin

### DIFF
--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
@@ -42,21 +42,14 @@ public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
     }
 
     /**
-     * Jar file to use as a source for the Smithy CLI validate command.
+     * Files to use as a sources for the Smithy CLI {@code validate} command.
      *
-     * <p>This is a required input for the {@link SmithyValidateTask}. In general
-     * this should be the output of a {@link org.gradle.jvm.tasks.Jar task}. For example:
+     * <p>This is a required input of the SmithyValidate task.
      *
-     * <pre>
-     *     Task jarTask = project.getTasks()
-     *      .getByName(JavaPlugin.JAR_TASK_NAME);
-     *     ...
-     *     validateTask.getJarToValidate().set(
-     *      jarTask.getOutputs().getFiles());
-     * </pre>
+     * @return file collection to use as sources for the validate task.
      */
     @InputFiles
-    public abstract Property<FileCollection> getJarToValidate();
+    public abstract Property<FileCollection> getSources();
 
     /**
      * Disable model discovery.
@@ -107,7 +100,7 @@ public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
 
         // Set models to an empty collection so source models are not included in validation path.
         executeCliProcess("validate", extraArgs,
-                getJarToValidate().get(),
+                getSources().get(),
                 getDisableModelDiscovery().get()
         );
     }

--- a/smithy-jar/src/main/java/software/amazon/smithy/gradle/SmithyJarPlugin.java
+++ b/smithy-jar/src/main/java/software/amazon/smithy/gradle/SmithyJarPlugin.java
@@ -140,8 +140,7 @@ public class SmithyJarPlugin implements Plugin<Project> {
 
                     // Only enable validation if the jar Task is also enabled
                     validateTask.setEnabled(jarTask.getEnabled());
-
-                    validateTask.getJarToValidate().set(jarTask.getOutputs().getFiles());
+                    validateTask.getSources().set(jarTask.getOutputs().getFiles());
                     validateTask.getAllowUnknownTraits().set(extension.getAllowUnknownTraits());
 
                     // Add to verification group, so this tasks shows up in the output of `gradle tasks`


### PR DESCRIPTION
#### Background
* Moves the validate task to the base plugin and changes the Sources property to be `Sources` instead of `JarToValidate` as this task could be used to validate any set of smithy sources.
* The validate task is more generally useful that just for validating a JAR file in the smithy-jar plugin. Eventually we plan to add validation reports to this task which might be added as part of the base plugin. Because this task can be used outside of a jar context it should not live in the smithy-jar plugin.

#### Testing
* Executed integration tests which already test validation capability

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
