### PR TITLE
Update link to smithy.io docs for the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ smithy {
 
 ## Documentation
 
-See https://smithy.io/2.0/guides/building-models/gradle-plugin.html
+See https://smithy.io/2.0/guides/gradle-plugin/index.html
 
 
 ## License


### PR DESCRIPTION
#### Background
The current link https://smithy.io/2.0/guides/building-models/gradle-plugin.html goes to https://smithy.io/2.0/guides/gradle-plugin.html which seems to be able for 0.6.0 version. Updated the link to latest.

#### Testing
* Looked at the new rendered README and clicked the link to verify it is as expected.

#### Links

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
