### PR TITLE
Add a new plugin for setting up a trait package

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,6 +10,11 @@ repositories {
     gradlePluginPortal()
 }
 
+// Prevent compatibility issues if an unsupported JDK is configured as default
+kotlin {
+    jvmToolchain(17)
+}
+
 dependencies {
     // Java convention dependencies
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.6")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,11 +10,6 @@ repositories {
     gradlePluginPortal()
 }
 
-// Prevent compatibility issues if an unsupported JDK is configured as default
-kotlin {
-    jvmToolchain(17)
-}
-
 dependencies {
     // Java convention dependencies
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.6")

--- a/examples/jar-plugin/kotlin-jvm-project/build.gradle.kts
+++ b/examples/jar-plugin/kotlin-jvm-project/build.gradle.kts
@@ -1,13 +1,8 @@
 // This project adds smithy models to a JAR created by a Kotlin project
 
 plugins {
-    kotlin("jvm") version "1.9.0"
+    kotlin("jvm") version "1.9.23"
     id("software.amazon.smithy.gradle.smithy-jar").version("1.0.0")
-}
-
-// Prevent compatibility issues if an unsupported JDK is configured as default
-kotlin {
-    jvmToolchain(17)
 }
 
 repositories {

--- a/examples/jar-plugin/kotlin-jvm-project/build.gradle.kts
+++ b/examples/jar-plugin/kotlin-jvm-project/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
     id("software.amazon.smithy.gradle.smithy-jar").version("1.0.0")
 }
 
+// Prevent compatibility issues if an unsupported JDK is configured as default
+kotlin {
+    jvmToolchain(17)
+}
+
 repositories {
     mavenLocal()
     mavenCentral()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,4 +2,5 @@ rootProject.name = "smithy-gradle"
 
 include("smithy-base")
 include("smithy-jar")
+include("smithy-trait-package")
 include("integ-test-utils")

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.FileCollection;
@@ -237,6 +238,18 @@ public final class SmithyUtils {
 
     public static Configuration getCliConfiguration(Project project) {
         return project.getConfigurations().getByName(SMITHY_CLI_CONFIGURATION_NAME);
+    }
+
+    /**
+     * Checks if a dependency matches an expected name.
+     *
+     * @param dependency Dependency to check
+     * @param name Name of expected dependency
+     * @return true if the dependency matches the expected name
+     */
+    public static boolean isMatchingDependency(Dependency dependency, String name) {
+        return Objects.equals(dependency.getGroup(), "software.amazon.smithy")
+                && dependency.getName().equals(name);
     }
 }
 

--- a/smithy-trait-package/build.gradle.kts
+++ b/smithy-trait-package/build.gradle.kts
@@ -1,0 +1,22 @@
+description = "Creates a ."
+
+plugins {
+    id("smithy-gradle-plugin.plugin-conventions")
+}
+
+gradlePlugin {
+    plugins {
+        create("smithy-trait-package-plugin") {
+            id = "${group}.smithy-trait-package"
+            displayName = "Smithy Gradle Trait Package plugin."
+            description = project.description
+            implementationClass = "software.amazon.smithy.gradle.SmithyTraitPackagePlugin"
+            tags.addAll("smithy", "api", "building")
+        }
+    }
+}
+
+dependencies {
+    implementation(project(":smithy-jar"))
+    implementation(project(":smithy-base"))
+}

--- a/smithy-trait-package/build.gradle.kts
+++ b/smithy-trait-package/build.gradle.kts
@@ -1,4 +1,5 @@
-description = "Creates a ."
+description = "Configures a Java library package for Smithy traits, using " +
+        "Smithy's trait-codegen plugin to generate Java implementation of traits."
 
 plugins {
     id("smithy-gradle-plugin.plugin-conventions")

--- a/smithy-trait-package/src/main/java/software/amazon/smithy/gradle/SmithyTraitPackagePlugin.java
+++ b/smithy-trait-package/src/main/java/software/amazon/smithy/gradle/SmithyTraitPackagePlugin.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.gradle;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import javax.inject.Inject;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.plugins.JavaLibraryPlugin;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
+import software.amazon.smithy.gradle.internal.CliDependencyResolver;
+
+/**
+ * A {@link org.gradle.api.Plugin} that adds sets up a package for a custom trait.
+ */
+public class SmithyTraitPackagePlugin implements Plugin<Project> {
+    private static final String SMITHY_TRAIT_CODEGEN_DEP_NAME = "smithy-trait-codegen";
+    private static final String TRAIT_CODEGEN_PLUGIN_NAME = "trait-codegen";
+    private static final String DEPENDENCY_NOTATION = "software.amazon.smithy:%s:%s";
+
+    private static final String SOURCE = "source";
+
+    private SmithyExtension extension;
+    private final Project project;
+
+    @Inject
+    public SmithyTraitPackagePlugin(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public void apply(Project project) {
+        project.getPlugins().apply(JavaLibraryPlugin.class);
+        project.getPlugins().apply(SmithyJarPlugin.class);
+
+        extension = project.getExtensions().getByType(SmithyExtension.class);
+
+        // Only configure trait codegen dependency for main sourceSet
+        project.getExtensions().getByType(SourceSetContainer.class).all(sourceSet -> {
+            if (SourceSet.isMain(sourceSet)) {
+                // Add Trait codegen outputs to source set
+                addGeneratedTraits(sourceSet);
+                project.afterEvaluate(p -> configureDependencies(sourceSet));
+            }
+        });
+    }
+
+    private void addGeneratedTraits(SourceSet sourceSet) {
+        Path pluginOutput = extension.getPluginProjectionPath(SOURCE, TRAIT_CODEGEN_PLUGIN_NAME).get();
+        sourceSet.getJava().srcDir(pluginOutput);
+        sourceSet.getResources().srcDir(pluginOutput).exclude("**/*.java");
+    }
+
+    // TODO: Add smithy-model dependency?
+    private void configureDependencies(SourceSet sourceSet) {
+        Configuration smithyBuild = project.getConfigurations()
+                .getByName(SmithyUtils.getSmithyBuildConfigurationName(sourceSet));
+
+        // Prefer explicit dependency
+        Optional<Dependency> explicitDepOptional = smithyBuild.getAllDependencies().stream()
+                .filter(d -> SmithyUtils.isMatchingDependency(d,
+                        SmithyTraitPackagePlugin.SMITHY_TRAIT_CODEGEN_DEP_NAME))
+                .findFirst();
+        if (explicitDepOptional.isPresent()) {
+            project.getLogger().info(String.format("(using explicitly configured Dependency for %s: %s)",
+                    SmithyTraitPackagePlugin.SMITHY_TRAIT_CODEGEN_DEP_NAME, explicitDepOptional.get().getVersion()));
+            return;
+        }
+
+        // If trait codegen does not exist, add the dependency with the same version as the resolved CLI version
+        String cliVersion = CliDependencyResolver.resolve(project);
+        project.getDependencies().add(smithyBuild.getName(),
+                String.format(DEPENDENCY_NOTATION, SmithyTraitPackagePlugin.SMITHY_TRAIT_CODEGEN_DEP_NAME, cliVersion));
+    }
+}


### PR DESCRIPTION
#### Background
Creates a new gradle plugin for quickly defining a smithy trait package. This plugin adds trait codegen to the 
smithyBuild dependencies if it does not already exist. The output of the trait codegen plugin is then added to the main java sourceset.  

Next steps: 
- Add a task to merge service provider files so existing traits can also live in the package.
- Add integration tests
- Possibly have the plugin auto-wire the smithy-model dependency

#### Testing
Manually tested with a local package. 
Additional tests will be added as part of the next steps and will require some additional setup.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
