### PR TITLE
Add convinence method which allows resolving plugin projection directories from SmithyBuild task instances

### DIFF
--- a/examples/base-plugin/smithy-build-task/build.gradle.kts
+++ b/examples/base-plugin/smithy-build-task/build.gradle.kts
@@ -9,12 +9,17 @@ plugins {
     id("software.amazon.smithy.gradle.smithy-base").version("1.0.0")
 }
 
-tasks.create<SmithyBuildTask>("doit") {
+val doIt = tasks.register<SmithyBuildTask>("doit") {
     models.set(files("model/"))
     smithyBuildConfigs.set(files("smithy-build.json"))
 }
 
-tasks["build"].finalizedBy(tasks["doit"])
+tasks["build"].finalizedBy(doIt)
+
+tasks.register<Sync>("copyOutput") {
+    into(layout.buildDirectory.dir("model"))
+    from(doIt.map { it.getPluginProjectionDirectory("source", "model") })
+}
 
 repositories {
     mavenLocal()

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/SmithyBuildTaskTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/SmithyBuildTaskTest.java
@@ -39,4 +39,19 @@ public class SmithyBuildTaskTest {
                     "build/smithyprojections/smithy-build-task/source/sources/manifest");
         });
     }
+
+    @Test
+    public void pluginProjectionDirectoryExpressesTaskDependency() {
+        Utils.withCopy("base-plugin/smithy-build-task", buildDir -> {
+            BuildResult result = GradleRunner.create()
+                    .forwardOutput()
+                    .withProjectDir(buildDir)
+                    .withArguments("copyOutput", "--stacktrace")
+                    .build();
+            Utils.assertSmithyBuildDidNotRun(result);
+            Utils.assertArtifactsCreated(
+                    buildDir,
+                    "build/model/model.json");
+        });
+    }
 }

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildTask.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.gradle.StartParameter;
 import org.gradle.api.GradleException;
+import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.model.ObjectFactory;
@@ -165,4 +166,19 @@ public abstract class SmithyBuildTask extends AbstractSmithyCliTask {
                 getFork().get()
         );
     }
+
+    /**
+     * Convenience method to get the directory containing plugin artifacts.
+     *
+     * @param projection projection name
+     * @param plugin name of plugin to get artifact directory for
+     *
+     * @return provider for the plugin artifact directory
+     */
+    public Provider<Directory> getPluginProjectionDirectory(String projection, String plugin) {
+        return getProject().getLayout().dir(
+                getOutputDir().getAsFile()
+                        .map(file -> SmithyUtils.getProjectionPluginPath(file, projection, plugin).toFile()));
+    }
+
 }


### PR DESCRIPTION
#### Background
Currently, the standardized method to resolve a given projection + plugin's path is via the `SmithyExtension` method `getPluginProjectionPath`.  This method will return a `Provider<Path>` based on the `outputDirectory` property defined in the extension.

This pull request adds a similar convenience method on the SmithBuildTask implementation itself.  The referenced location is functionally the same in most normal setups.  In Gradle, utilizing a provider that is based off of the task implementation's `DirectoryProperty` instead of the extension's `DirectoryProperty`, even if the task's instance is bound to the extension's instance, will express the implicit dependency between task definitions.

That is, running `./gradlew copyOutput` on this task implementation will not execute the `smithyBuild` task:
```
tasks.register<Sync>("copyOutput") {
    into(layout.buildDirectory.dir("model"))
    from(smithy.getPluginProjectionPath("source", "model"))
}
```

Correct behavior requires an explicit dependency:
```
tasks.register<Sync>("copyOutput") {
    dependsOn(smithyBuild)

    into(layout.buildDirectory.dir("model"))
    from(smithy.getPluginProjectionPath("source", "model"))
}
```

With this update, this will work as expected and express the dependency upon `smithyBuild`  correctly:
```
tasks.register<Sync>("copyOutput") {
    into(layout.buildDirectory.dir("model"))
    from(smithyBuild.map { it.getPluginProjectionDirectory("source", "model") })
}
```


In the implementaiton, I chose to express it as a `Provider<Directory>` instead of `Provider<Path>` because utilizing the Gradle-provided `Directory` and similar api definitions aid in further idiomatic resolution of child directories and files over the Path class.

#### Testing
* Implemented integration test built on the smithy-build-task example that shows usage and verifies behavior

#### Links
N/A

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
