### PR TITLE
Update minimum log severity for smithy validate task

### DIFF
--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
@@ -37,7 +37,7 @@ public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
         super(objectFactory, startParameter);
         getAllowUnknownTraits().convention(false);
         getDisableModelDiscovery().convention(false);
-        getSeverity().convention(Severity.ERROR.toString());
+        getSeverity().convention(Severity.DANGER.toString());
         setDescription(DESCRIPTION);
     }
 


### PR DESCRIPTION
#### Background
Updates the minimum severity for logging in validate task to `DANGER` as unsuppressed DANGER events can still cause the validation to fail. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
