### PR TITLE
Remove JDK 8, 11 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Java ${{ matrix.java }} ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11, 17]
+        java: [17]
         os: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
#### Background
* The CI for this repo pulls the smithy repo locally and builds it
  * However, the smithy repo only supports builds on JDK17 and above 
* Removes 8 and 11 builds

#### Links
* https://github.com/smithy-lang/smithy/pull/2487

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
