### PR TITLE
Declare task output for validate and format tasks so they are incremental

### DIFF
--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyBasePlugin.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyBasePlugin.java
@@ -158,6 +158,7 @@ public final class SmithyBasePlugin implements Plugin<Project> {
                 formatTask -> {
                     formatTask.getModels().set(sds.getSourceDirectories());
                     formatTask.setEnabled(extension.getFormat().get());
+                    formatTask.getOutputs().upToDateWhen(s -> true);
                 });
 
         // Smithy files should be formatted before they are built

--- a/smithy-jar/src/main/java/software/amazon/smithy/gradle/SmithyJarPlugin.java
+++ b/smithy-jar/src/main/java/software/amazon/smithy/gradle/SmithyJarPlugin.java
@@ -145,6 +145,7 @@ public class SmithyJarPlugin implements Plugin<Project> {
 
                     // Add to verification group, so this tasks shows up in the output of `gradle tasks`
                     validateTask.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
+                    validateTask.getOutputs().upToDateWhen(s -> true);
                 });
         project.getTasks().getByName("test").dependsOn(validateTaskProvider);
     }


### PR DESCRIPTION
#### Background
- These tasks do not declare any outputs, therefore they are never considered up-to-date by gradle
- This change adds dummy outputs to these tasks
  - The real outputs are the same as the inputs, but marking the inputs as outputs becomes problematic when there are cross-project task dependencies 

#### Testing
- Create a project that uses the smithy jar plugin
- Use a maven-local version, and run pTML with these changes
- Run `smithyValidate -i`, verify it (and `smithyFormat`) runs
- Run `smithyValidate -i` again, verify it (and `smithyFormat`) is marked up-to-date and not re-ran

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
