### PR TITLE
Fix incremental behaviour of validate task

### DIFF
--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
@@ -39,6 +39,7 @@ public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
         getDisableModelDiscovery().convention(false);
         getSeverity().convention(Severity.DANGER.toString());
         setDescription(DESCRIPTION);
+        getOutputs().upToDateWhen(t -> true);
     }
 
     /**

--- a/smithy-jar/src/main/java/software/amazon/smithy/gradle/SmithyJarPlugin.java
+++ b/smithy-jar/src/main/java/software/amazon/smithy/gradle/SmithyJarPlugin.java
@@ -145,7 +145,6 @@ public class SmithyJarPlugin implements Plugin<Project> {
 
                     // Add to verification group, so this tasks shows up in the output of `gradle tasks`
                     validateTask.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
-                    validateTask.getOutputs().upToDateWhen(s -> true);
                 });
         project.getTasks().getByName("test").dependsOn(validateTaskProvider);
     }


### PR DESCRIPTION
#### Background
* For some reason #155 does not work for validate task. I attached a debugger and I can see Gradle's DefaultMutationGuard blocking an update to the upToDateWhen. The DefaultMutationGuard is bytecode instrumented, so the debugger isn't able to pinpoint the exact line of code doing this.
* As a workaround setting this in the ValidateTask constructor works.

#### Testing
* Checkout smithy-java project.
* Publish changes to mavenLocal.
* Run `./gradlew :framework-errors:smithyJarValidate`, verify it runs the smithy validate task.
* Run `./gradlew :framework-errors:smithyJarValidate`, this time it should not run the task.

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
