### PR TITLE
Set classpaths for select

### DIFF
--- a/buildSrc/src/main/kotlin/smithy-gradle-plugin.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-gradle-plugin.java-conventions.gradle.kts
@@ -10,9 +10,9 @@ java {
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:[1.0, 2.0[")
-    implementation("software.amazon.smithy:smithy-build:[1.0, 2.0[")
-    implementation("software.amazon.smithy:smithy-cli:[1.0, 2.0[")
+    implementation("software.amazon.smithy:smithy-model:[1.60.2, 2.0[")
+    implementation("software.amazon.smithy:smithy-build:[1.60.2, 2.0[")
+    implementation("software.amazon.smithy:smithy-cli:[1.60.2, 2.0[")
 }
 
 //// ==== Licensing =====

--- a/examples/base-plugin/uses-explicitly-set-cli-version/build.gradle.kts
+++ b/examples/base-plugin/uses-explicitly-set-cli-version/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    smithyCli("software.amazon.smithy:smithy-cli:1.45.0")
+    smithyCli("software.amazon.smithy:smithy-cli:1.60.2")
 }
 
 repositories {

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/SelectTaskTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/SelectTaskTest.java
@@ -60,4 +60,21 @@ public class SelectTaskTest {
             Assertions.assertTrue(result.getOutput().contains("\"smithy.api#documentation\": \"a string member\""));
         });
     }
+
+    @Test
+    public void selectUsesGradleClasspath() {
+        Utils.withCopy("base-plugin/output-directory", buildDir -> {
+            BuildResult result = GradleRunner.create()
+                    .forwardOutput()
+                    .withProjectDir(buildDir)
+                    .withArguments("select", "--selector", "operation[trait|aws.auth#unsignedPayload]")
+                    .build();
+
+            Utils.assertSmithyBuildDidNotRun(result);
+            Utils.assertArtifactsNotCreated(buildDir,
+                    "build/smithyprojections/output-directory/source/build-info/smithy-build-info.json");
+
+            Assertions.assertTrue(result.getOutput().contains("smithy.example#Foo"));
+        });
+    }
 }

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyBasePlugin.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyBasePlugin.java
@@ -171,11 +171,16 @@ public final class SmithyBasePlugin implements Plugin<Project> {
                                            SmithyExtension extension
     ) {
         String taskName = SmithyUtils.getRelativeSourceSetName(sourceSet, SMITHY_SELECT_TASK_NAME);
+        String runtimeConfigName = sourceSet.getRuntimeClasspathConfigurationName();
         project.getTasks().register(taskName, SmithySelectTask.class, selectTask -> {
             selectTask.setDescription("Selects smithy models in " + sourceSet.getName() + " source set.");
             selectTask.getAllowUnknownTraits().set(extension.getAllowUnknownTraits());
             selectTask.getModels().set(sds.getSourceDirectories());
             selectTask.getFork().set(extension.getFork());
+            selectTask.getCliClasspath().set(project.getConfigurations()
+                    .getByName(SmithyUtils.SMITHY_CLI_CONFIGURATION_NAME));
+            selectTask.getModelDiscoveryClasspath().set(project.getConfigurations()
+                    .getByName(runtimeConfigName));
         });
     }
 


### PR DESCRIPTION
This updates the select command to set its classpaths. This is necessary to be able to run select on projects with dependencies without having to set the allow unknown traits flag, which you shouldn't have to do.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
