### PR TITLE
Fix incorrectly configured failure test

### DIFF
--- a/examples/base-plugin/failure-cases/syntax-error/build.gradle.kts
+++ b/examples/base-plugin/failure-cases/syntax-error/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     id("java-library")
-    id("smith-base").version("0.7.0")
+    id("software.amazon.smithy.gradle.smithy-base").version("1.3.0")
 }
 
 repositories {


### PR DESCRIPTION
The syntax error test was incorrectly configured, so it would fail for the wrong reason. It actually still will because smithyFormat is disabled and that will cause a different failure mode. But this is at least a step in the right direction.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
