### PR TITLE
Added "staging" area of smithy-jar plugin as excluded in IntelliJ

### DIFF
--- a/smithy-jar/src/main/java/software/amazon/smithy/gradle/SmithyJarPlugin.java
+++ b/smithy-jar/src/main/java/software/amazon/smithy/gradle/SmithyJarPlugin.java
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.language.jvm.tasks.ProcessResources;
+import org.gradle.plugins.ide.idea.IdeaPlugin;
 import software.amazon.smithy.gradle.actions.SmithyManifestUpdateAction;
 import software.amazon.smithy.gradle.tasks.SmithyBuildTask;
 import software.amazon.smithy.gradle.tasks.SmithyJarStagingTask;
@@ -55,6 +56,7 @@ public class SmithyJarPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        project.getPlugins().apply("idea");
         project.getPlugins().apply(SmithyBasePlugin.class);
 
         extension = project.getExtensions().getByType(SmithyExtension.class);
@@ -108,6 +110,21 @@ public class SmithyJarPlugin implements Plugin<Project> {
         File metaInf = jarStagingTaskProvider.get().getSmithyMetaInfDir().get();
         project.getLogger().debug("Registering Smithy resource artifacts with Java resources: {}", metaInf);
         SourceDirectorySet metaInfSrcDir = sourceSet.getResources().srcDir(metaInf);
+
+        IdeaPlugin ideaPlugin = project.getPlugins().getPlugin(IdeaPlugin.class);
+
+        // by adding the generated "staging" are to the resources source set
+        // it gets added as a "resources root" in IntelliJ
+        // and if you're using Smithy plugin https://github.com/smithy-lang/smithy-intellij-plugin
+        // it is using this folder to look up for smithy files (which are copies of the source files)
+        // because this folder contains the copy of source smithy files
+        // this causes issues where for instance when you navigate to a shape,
+        // IntelliJ will go to a "staging" folder over the source
+        // (even if it is located in the same file as you're currently in!)
+        // or worse, when you removed a shape/trait, but still see it as "available" in IDE
+        // but when you run (clean) build it fails
+        // so marking this folder as "excluded" just for IntelliJ solves these problems
+        ideaPlugin.getModel().getModule().getExcludeDirs().add(metaInf);
 
         // This plugin supports loading Smithy models from various locations, including
         // META-INF/smithy. It also creates a staging directory for all the merged


### PR DESCRIPTION
#### Background

Currently, if you're using IntelliJ, [Smithy IntelliJ Plugin](https://github.com/smithy-lang/smithy-intellij-plugin) and `smithy-jar` plugin in one of the modules you have a couple of issues:
- using "go to declaration" navigates you to a staging area of `SmithyJarStagingTask` task, even if a shape is located in the same files as you're currently in
- if you edit the source model, e.g. removed a shape, you still see it as being available because it was loaded from the staging resources source set, and only clean build helps (a normal build might help as well but only if you didn't remove a file). this provides a poor DX imo

Based on my understanding, this is caused by multiple factors:
- IntelliJ loads Gradle projects and treats their source sets as sources folders
- All IntelliJ plugins are using this structure in order to load "available files"
- `smithy-jar` plugin adds a staging folder to the resources source set while it is not quite the source, not for IDE at least (only for the build system)

It is worth nothing that there is no such issue with LSP-based integrations such as VSCode.

#### Testing

I applied this fix locally and tested on my local projects.

#### Links
* Links to additional context, if necessary
* Issue #, if applicable (see [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for a list of keywords to use for linking issues)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
