### PR TITLE
Configure idea source sets by default

### DIFF
--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyBasePlugin.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyBasePlugin.java
@@ -17,6 +17,7 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
+import org.gradle.plugins.ide.idea.IdeaPlugin;
 import org.gradle.util.GradleVersion;
 import software.amazon.smithy.gradle.internal.CliDependencyResolver;
 import software.amazon.smithy.gradle.tasks.SmithyBuildTask;
@@ -60,6 +61,7 @@ public final class SmithyBasePlugin implements Plugin<Project> {
 
         // Creates required configurations and base source set container
         project.getPlugins().apply(JavaBasePlugin.class);
+        project.getPlugins().apply(IdeaPlugin.class);
 
         // Add smithy source set extension
         SmithyExtension smithyExtension = project.getExtensions().create("smithy", SmithyExtension.class);
@@ -106,10 +108,18 @@ public final class SmithyBasePlugin implements Plugin<Project> {
             // Resolve the Smithy CLI artifact
             CliDependencyResolver.resolve(p);
 
+            IdeaPlugin ideaPlugin = p.getPlugins().getPlugin(IdeaPlugin.class);
+
             p.getExtensions().getByType(SourceSetContainer.class).all(sourceSet -> {
+                SmithySourceDirectorySet sds = sourceSet.getExtensions().getByType(SmithySourceDirectorySet.class);
+
+                // Register Smithy source directories as IDEA source roots so that the
+                // smithy-intellij-plugin can discover and index models from their actual
+                // locations rather than relying on staging copies or missing them entirely.
+                ideaPlugin.getModel().getModule().getSourceDirs().addAll(sds.getSrcDirs());
+
                 // Add format task for source set if enabled
                 if (extension.getFormat().get()) {
-                    SmithySourceDirectorySet sds = sourceSet.getExtensions().getByType(SmithySourceDirectorySet.class);
                     addFormatTaskForSourceSet(sourceSet, sds, extension);
                 }
             });

--- a/smithy-jar/src/main/java/software/amazon/smithy/gradle/SmithyJarPlugin.java
+++ b/smithy-jar/src/main/java/software/amazon/smithy/gradle/SmithyJarPlugin.java
@@ -56,7 +56,6 @@ public class SmithyJarPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getPlugins().apply("idea");
         project.getPlugins().apply(SmithyBasePlugin.class);
 
         extension = project.getExtensions().getByType(SmithyExtension.class);


### PR DESCRIPTION
This updates the base gradle plugin to configure idea source sets by default. This gets rid of that annoying message about model files not being part of a source set despite being perfectly resolveable.

Inspired by reading #167 and realizing that we can do more here in the gradle plugin to make intellij and friends work as they should.

Before:

<img width="1512" height="949" alt="Screenshot 2026-07-07 at 16 42 16" src="https://github.com/user-attachments/assets/849ffa6a-f97f-4fd6-9267-aa8faec7ad96" />

After:

<img width="1512" height="949" alt="Screenshot 2026-07-07 at 16 41 08" src="https://github.com/user-attachments/assets/99328cfe-1ebb-41c2-9026-7335e6a3d84d" />

Note that the inter-project deps still aren't wired up quite right, but I don't think we can solve that here without some crazy workarounds that might break things.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
