### PR TITLE
Add dependabot config and update ci to run multiple gradle versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+     - "dependencies"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+     - "dependencies"
+     - "no-changelog-needed"
+    groups:
+      gradle:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # These versions are deliberaly kept at a range that we only want to
+      # update when we need to.
+      - dependency-name: "software.amazon.smithy:smithy-model"
+      - dependency-name: "software.amazon.smithy:smithy-build"
+      - dependency-name: "software.amazon.smithy:smithy-cli"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate-wrapper:
     name: "Validate Gradle Wrapper"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
         if: ${{ matrix.gradle != 'wrapper' }}
         run: |
           cd smithy-gradle-plugin
-          ./gradlew clean integTest -PgradleTestVersion=${{ steps.setup-gradle.outputs.gradle-version }} -Plog-tests
+          ./gradlew clean integTest -PgradleTestVersion="${{ steps.setup-gradle.outputs.gradle-version }}" -Plog-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,40 +7,71 @@ on:
     branches: [main]
 
 jobs:
+  validate-wrapper:
+    name: "Validate Gradle Wrapper"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: gradle/actions/wrapper-validation@v6
+
   build:
     runs-on: ${{ matrix.os }}
-    name: Java ${{ matrix.java }} ${{ matrix.os }}
+    name: Java ${{ matrix.java }} Gradle ${{ matrix.gradle }} ${{ matrix.os }}
     strategy:
       matrix:
         java: [17]
         os: [ubuntu-latest, windows-latest]
+        gradle:
+          - '8.2'      # Our declared minimum version
+          - 'wrapper'  # The version in our gradle wrapper
+          - 'current'  # The current stable release
 
     steps:
       - name: Checkout smithy-gradle-plugin
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           path: smithy-gradle-plugin
 
       # We checkout smithy main here since we will often require changes that
       # have not yet been released but have been merged.
       - name: Checkout smithy main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           repository: awslabs/smithy
           path: smithy
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'corretto'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        id: setup-gradle
+        with:
+          gradle-version: ${{ matrix.gradle }}
 
       - name: Publish smithy main to maven local
         run: |
           cd smithy
           ./gradlew clean publishToMavenLocal
 
-      - name: Clean and build smithy-gradle-plugin
+      # The unit tests don't need to be run under each gradle version as their
+      # behavior won't change. So here we run the full test suite when the
+      # wrapper version is being used. This also runs the integ tests since it's
+      # wired into build.
+      - name: Build and test
+        if: ${{ matrix.gradle == 'wrapper' }}
         run: |
           cd smithy-gradle-plugin
-          ./gradlew clean publishToMavenLocal
-          ./gradlew -g $PWD build -Plog-tests
+          ./gradlew clean build -Plog-tests
+
+      # When we're not running the wrapper version, we only need to run the
+      # integ tests. We can use the output of the setup-gradle action to
+      # get the realized version for aliases like 'current'.
+      - name: Run integ tests
+        if: ${{ matrix.gradle != 'wrapper' }}
+        run: |
+          cd smithy-gradle-plugin
+          ./gradlew clean integTest -PgradleTestVersion=${{ steps.setup-gradle.outputs.gradle-version }} -Plog-tests

--- a/buildSrc/src/main/kotlin/smithy-gradle-plugin.plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-gradle-plugin.plugin-conventions.gradle.kts
@@ -116,6 +116,14 @@ tasks.register<Test>("integTest") {
     testClassesDirs = sourceSets["it"].output.classesDirs
     classpath = sourceSets["it"].runtimeClasspath
     maxParallelForks = Runtime.getRuntime().availableProcessors() / 2
+
+    // Optionally run the integ tests against a specific Gradle version. When unset,
+    // they use the version running this task (the wrapper). CI sets this to exercise
+    // consumers against our declared minimum and the current release while still
+    // building with the wrapper.
+    providers.gradleProperty("gradleTestVersion").orNull?.let {
+        systemProperty("gradleTestVersion", it)
+    }
 }
 
 afterEvaluate {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/integ-test-utils/src/main/java/software/amazon/smithy/gradle/Utils.java
+++ b/integ-test-utils/src/main/java/software/amazon/smithy/gradle/Utils.java
@@ -34,12 +34,38 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Assertions;
 import software.amazon.smithy.utils.IoUtils;
 
 public final class Utils {
+    /**
+     * System property used to run the integ tests against a specific Gradle version.
+     *
+     * <p>When unset, the tests use the same Gradle version that runs the
+     * {@code integTest} task, i.e. the wrapper version. CI sets this to exercise
+     * consumers against our declared minimum and the current release while still
+     * building and publishing the plugin with the wrapper.
+     */
+    public static final String GRADLE_TEST_VERSION_PROPERTY = "gradleTestVersion";
+
     private Utils() {}
+
+    /**
+     * Creates a {@link GradleRunner} for exercising a consumer build, honoring the
+     * {@value #GRADLE_TEST_VERSION_PROPERTY} system property when it is set.
+     *
+     * @return a runner pinned to the requested Gradle version, or the default version when unset.
+     */
+    public static GradleRunner createGradleRunner() {
+        GradleRunner runner = GradleRunner.create();
+        String gradleTestVersion = System.getProperty(GRADLE_TEST_VERSION_PROPERTY);
+        if (gradleTestVersion != null && !gradleTestVersion.isEmpty()) {
+            runner.withGradleVersion(gradleTestVersion);
+        }
+        return runner;
+    }
 
     public static Path createTempDir(String name) {
         try {

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/ConflictingOutputDirectoriesTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/ConflictingOutputDirectoriesTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -9,7 +8,7 @@ public class ConflictingOutputDirectoriesTest {
     @Test
     public void testConflictingConfigs() {
         Utils.withCopy("base-plugin/failure-cases/conflicting-output-dir-configs", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/ForbidDependencyResolutionTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/ForbidDependencyResolutionTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -9,7 +8,7 @@ public class ForbidDependencyResolutionTest {
     @Test
     public void testNoFork() {
         Utils.withCopy("base-plugin/failure-cases/forbid-dependency-resolution-no-fork", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
@@ -25,7 +24,7 @@ public class ForbidDependencyResolutionTest {
     @Test
     public void testFork() {
         Utils.withCopy("base-plugin/failure-cases/forbid-dependency-resolution-fork", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/ForbidImplicitNoBuildConfigTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/ForbidImplicitNoBuildConfigTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -9,7 +8,7 @@ public class ForbidImplicitNoBuildConfigTest {
     @Test
     public void testExceptionThrows() {
         Utils.withCopy("base-plugin/failure-cases/forbid-implicit-no-build-config", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/IncludesInSourceSetTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/IncludesInSourceSetTest.java
@@ -1,14 +1,13 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 public class IncludesInSourceSetTest {
     @Test
     public void testSourceProjection() {
         Utils.withCopy("base-plugin/includes-in-sourceset", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/OutputDirectoryConfigTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/OutputDirectoryConfigTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -10,7 +9,7 @@ public class OutputDirectoryConfigTest {
     @Test
     public void testOutputDirectoryBuild() {
         Utils.withCopy("base-plugin/output-directory-config", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/OutputDirectoryTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/OutputDirectoryTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -17,7 +16,7 @@ public class OutputDirectoryTest {
         File outputDir = buildDirPath.resolve("build").resolve("nested-output-directory").toFile();
         try {
             Utils.copyProject(projectName, buildDir);
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/OutputDirectoryWithProjectionTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/OutputDirectoryWithProjectionTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -17,7 +16,7 @@ public class OutputDirectoryWithProjectionTest {
         File outputDir = buildDirPath.resolve("build").resolve("nested-output-directory").toFile();
         try {
             Utils.copyProject(projectName, buildDir);
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/ScansForCliVersionTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/ScansForCliVersionTest.java
@@ -1,14 +1,13 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 public class ScansForCliVersionTest {
     @Test
     public void scansForCliVersion() {
         Utils.withCopy("base-plugin/scans-for-cli-version", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/SelectTaskTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/SelectTaskTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.node.Node;
@@ -10,7 +9,7 @@ public class SelectTaskTest {
     @Test
     public void selectsString() {
         Utils.withCopy("base-plugin/uses-explicitly-set-cli-version", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("select", "--selector", "member")
@@ -28,7 +27,7 @@ public class SelectTaskTest {
     @Test
     public void selectsWithShowString() {
         Utils.withCopy("base-plugin/uses-explicitly-set-cli-version", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("select", "--selector", "member", "--show", "type,vars")
@@ -46,7 +45,7 @@ public class SelectTaskTest {
     @Test
     public void selectsWithShowTraitsString() {
         Utils.withCopy("base-plugin/uses-explicitly-set-cli-version", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("select", "--selector", "structure > member", "--show-traits", "documentation", "--stacktrace")
@@ -64,7 +63,7 @@ public class SelectTaskTest {
     @Test
     public void selectUsesGradleClasspath() {
         Utils.withCopy("base-plugin/output-directory", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("select", "--selector", "operation[trait|aws.auth#unsignedPayload]")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/SmithyBuildTaskTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/SmithyBuildTaskTest.java
@@ -16,7 +16,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -25,7 +24,7 @@ public class SmithyBuildTaskTest {
     @Test
     public void testCustomBuild() {
         Utils.withCopy("base-plugin/smithy-build-task", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("build", "--stacktrace")
@@ -43,7 +42,7 @@ public class SmithyBuildTaskTest {
     @Test
     public void pluginProjectionDirectoryExpressesTaskDependency() {
         Utils.withCopy("base-plugin/smithy-build-task", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("copyOutput", "--stacktrace")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/SmithyFormatTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/SmithyFormatTest.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -25,7 +24,7 @@ public class SmithyFormatTest {
     @Test
     public void checkTaskFailsWithoutModifyingFiles() {
         Utils.withCopy("base-plugin/format-check", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("smithyFormatCheck", "--stacktrace")
@@ -48,7 +47,7 @@ public class SmithyFormatTest {
     @Test
     public void formatTaskReformatsFiles() {
         Utils.withCopy("base-plugin/format-check", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("smithyFormat", "--stacktrace")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/SyntaxErrorFormatTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/SyntaxErrorFormatTest.java
@@ -6,7 +6,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -21,7 +20,7 @@ public class SyntaxErrorFormatTest {
     @Test
     public void formatTaskFailsWithReadableMessageOnSyntaxError() {
         Utils.withCopy("base-plugin/failure-cases/syntax-error-format", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("smithyFormat", "--stacktrace")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/SyntaxErrorTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/SyntaxErrorTest.java
@@ -1,13 +1,12 @@
 package software.amazon.smithy.gradle;
 
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 public class SyntaxErrorTest {
     @Test
     public void testFailsWithSyntaxError() {
         Utils.withCopy("base-plugin/failure-cases/syntax-error", buildDir -> {
-            GradleRunner.create()
+            Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/UsesExplicitlySetCLIVersionTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/UsesExplicitlySetCLIVersionTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -9,7 +8,7 @@ public class UsesExplicitlySetCLIVersionTest {
     @Test
     public void usesExplicitCliVersion() {
         Utils.withCopy("base-plugin/uses-explicitly-set-cli-version", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "-i", "--stacktrace")

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyBasePlugin.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyBasePlugin.java
@@ -45,7 +45,7 @@ public final class SmithyBasePlugin implements Plugin<Project> {
      */
     public static final String SMITHY_FORMAT_CHECK_TASK_NAME = "smithyFormatCheck";
 
-    private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("8.2.0");
+    private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("8.2");
 
     private final Project project;
 

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/AddsTagsTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/AddsTagsTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -17,7 +16,7 @@ public class AddsTagsTest {
     @Test
     public void addsSmithyTagsToJars() {
         Utils.withCopy("jar-plugin/adds-tags", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/BuildDependenciesTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/BuildDependenciesTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
@@ -19,7 +18,7 @@ public class BuildDependenciesTest {
     @Test
     public void buildsCorrectlyWithSmithyBuildDependencies() {
         Utils.withCopy("jar-plugin/build-dependencies", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/CustomTraitTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/CustomTraitTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +11,7 @@ public class CustomTraitTest {
     @Test
     public void testCustomTrait() {
         Utils.withCopy("jar-plugin/custom-trait", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/DisableJarTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/DisableJarTest.java
@@ -1,14 +1,13 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 public class DisableJarTest {
     @Test
     public void testProjection() {
         Utils.withCopy("jar-plugin/disable-jar", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/InvalidProjectionTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/InvalidProjectionTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -9,7 +8,7 @@ public class InvalidProjectionTest {
     @Test
     public void testProjection() {
         Utils.withCopy("jar-plugin/failure-cases/invalid-projection", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/KotlinJvmProjectTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/KotlinJvmProjectTest.java
@@ -1,14 +1,13 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 public class KotlinJvmProjectTest {
     @Test
     public void testSourceProjection() {
         Utils.withCopy("jar-plugin/kotlin-jvm-project", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/MissingRuntimeDependencyTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/MissingRuntimeDependencyTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -9,7 +8,7 @@ public class MissingRuntimeDependencyTest {
     @Test
     public void testProjection() {
         Utils.withCopy("jar-plugin/failure-cases/missing-runtime-dependency", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/MultiProjectTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/MultiProjectTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +19,7 @@ public class MultiProjectTest {
     @Test
     public void testProjection() {
         Utils.withCopy("jar-plugin/multi-project", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/MultipleJarsTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/MultipleJarsTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -17,7 +16,7 @@ public class MultipleJarsTest {
     @Test
     public void addsSmithyTagsToJars() {
         Utils.withCopy("jar-plugin/multiple-jars", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/MultipleSourcesTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/MultipleSourcesTest.java
@@ -1,14 +1,13 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 public class MultipleSourcesTest {
     @Test
     public void testProjection() {
         Utils.withCopy("jar-plugin/multiple-sources", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/NoModelsTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/NoModelsTest.java
@@ -1,14 +1,13 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 public class NoModelsTest {
     @Test
     public void createsJarWithNoModels() {
         Utils.withCopy("jar-plugin/no-models", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/ProjectionTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/ProjectionTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -12,7 +11,7 @@ public class ProjectionTest {
     @Test
     public void testProjection() {
         Utils.withCopy("jar-plugin/projection", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
@@ -40,7 +39,7 @@ public class ProjectionTest {
     @Test
     public void usesWarningLoggingByDefault() {
         Utils.withCopy("jar-plugin/projection", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build")
@@ -54,7 +53,7 @@ public class ProjectionTest {
     @Test
     public void modifiesLogging() {
         Utils.withCopy("jar-plugin/projection", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--info")
@@ -66,7 +65,7 @@ public class ProjectionTest {
     @Test
     public void usesDebugMode() {
         Utils.withCopy("jar-plugin/projection", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--debug")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/ProjectsWithTagsTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/ProjectsWithTagsTest.java
@@ -1,7 +1,6 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.model.Model;
@@ -11,7 +10,7 @@ public class ProjectsWithTagsTest {
     @Test
     public void testProjectionWithSourceTags() {
         Utils.withCopy("jar-plugin/projects-with-tags", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/ScalaProjectTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/ScalaProjectTest.java
@@ -1,14 +1,13 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 public class ScalaProjectTest {
     @Test
     public void testScalaProject() {
         Utils.withCopy("jar-plugin/scala-project", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-jar/src/it/java/software/amazon/smithy/gradle/SourceProjectionTest.java
+++ b/smithy-jar/src/it/java/software/amazon/smithy/gradle/SourceProjectionTest.java
@@ -1,14 +1,13 @@
 package software.amazon.smithy.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 public class SourceProjectionTest {
     @Test
     public void testSourceProjection() {
         Utils.withCopy("jar-plugin/source-projection", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")
@@ -35,7 +34,7 @@ public class SourceProjectionTest {
     @Test
     public void testSourceProjectionWithConfigurationCaching() {
         Utils.withCopy("jar-plugin/source-projection", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace", "--configuration-cache")

--- a/smithy-trait-package/src/it/java/software/amazon/smithy/gradle/CreatesCustomTraitTest.java
+++ b/smithy-trait-package/src/it/java/software/amazon/smithy/gradle/CreatesCustomTraitTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.junit.jupiter.api.Test;
 
 public class CreatesCustomTraitTest {
@@ -12,7 +11,7 @@ public class CreatesCustomTraitTest {
     @Test
     public void createsTraitsAndAddsToJar() {
         Utils.withCopy("trait-package-plugin/create-simple-trait", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")

--- a/smithy-trait-package/src/it/java/software/amazon/smithy/gradle/RespectsManualTraitTest.java
+++ b/smithy-trait-package/src/it/java/software/amazon/smithy/gradle/RespectsManualTraitTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import org.gradle.testkit.runner.BuildResult;
-import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,7 @@ public class RespectsManualTraitTest {
     @Test
     public void respectsExistingTraitAndMergesSpiFiles() {
         Utils.withCopy("trait-package-plugin/use-with-existing-trait", buildDir -> {
-            BuildResult result = GradleRunner.create()
+            BuildResult result = Utils.createGradleRunner()
                     .forwardOutput()
                     .withProjectDir(buildDir)
                     .withArguments("clean", "build", "--stacktrace")


### PR DESCRIPTION
This adds a dependabot config to keep things up to date. It also updates CI to run integ tests on the minimum supported gradle version, the wrapper version, and the current stable version.

Updating the wrapper to the current 9.x stable version is out of scope here because we would need to make some structural changes. But at least we can make sure it's working for customers that are running the plugin in that version.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
