### PR TITLE
Move deps to version catalog and update junit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ import org.jreleaser.model.Active
 
 plugins {
     base
-    id("org.jreleaser") version "1.25.0"
+    alias(libs.plugins.jreleaser)
 }
 
 val pluginVersion = project.file("VERSION").readText().replace(System.lineSeparator(), "")
@@ -65,7 +65,7 @@ jreleaser {
                 create("maven-central") {
                     active = Active.ALWAYS
                     url = "https://central.sonatype.com/api/v1/publisher"
-                    stagingRepositories.add("${rootProject.buildDir}/staging")
+                    stagingRepositories.add(stagingDir().get().asFile.path)
                     maxRetries = 100
                     retryDelay = 60
                 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,9 +12,13 @@ repositories {
 
 dependencies {
     // Java convention dependencies
-    implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.4.8")
-    implementation("com.adarshr:gradle-test-logger-plugin:4.0.0")
+    implementation(libs.spotbugs)
+    implementation(libs.test.logger)
 
     // Plugin convention dependencies
-    implementation("com.gradle.publish:plugin-publish-plugin:1.3.1")
+    implementation(libs.plugin.publish)
+
+    // Make the generated version catalog accessors (LibrariesForLibs) available
+    // to precompiled script plugins. https://github.com/gradle/gradle/issues/15383
+    implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,8 @@
+// Ensure version library is available to buildSrc plugins
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/Extensions.kt
+++ b/buildSrc/src/main/kotlin/Extensions.kt
@@ -1,0 +1,10 @@
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+
+// JReleaser publishes artifacts from a local staging repository, rather than maven local.
+// https://jreleaser.org/guide/latest/examples/maven/staging-artifacts.html#_gradle
+fun Project.stagingDir(): Provider<Directory> {
+    // We should use the root build directory
+    return rootProject.layout.buildDirectory.dir("staging")
+}

--- a/buildSrc/src/main/kotlin/smithy-gradle-plugin.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-gradle-plugin.java-conventions.gradle.kts
@@ -4,15 +4,18 @@ plugins {
     checkstyle
 }
 
+// Workaround per: https://github.com/gradle/gradle/issues/15383
+val Project.libs get() = the<org.gradle.accessors.dm.LibrariesForLibs>()
+
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-model:[1.60.2, 2.0[")
-    implementation("software.amazon.smithy:smithy-build:[1.60.2, 2.0[")
-    implementation("software.amazon.smithy:smithy-cli:[1.60.2, 2.0[")
+    implementation(libs.smithy.model)
+    implementation(libs.smithy.build)
+    implementation(libs.smithy.cli)
 }
 
 //// ==== Licensing =====

--- a/buildSrc/src/main/kotlin/smithy-gradle-plugin.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-gradle-plugin.java-conventions.gradle.kts
@@ -7,9 +7,16 @@ plugins {
 // Workaround per: https://github.com/gradle/gradle/issues/15383
 val Project.libs get() = the<org.gradle.accessors.dm.LibrariesForLibs>()
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+// Compile production sources against the Java 8 API so the plugins keep supporting
+// Java 8 consumers.
+tasks.compileJava {
+    options.release.set(8)
+}
+
+// JUnit 6 requires Java 17, so tests are compiled against the Java 17 API even though
+// the production sources they exercise remain Java 8 compatible.
+tasks.compileTestJava {
+    options.release.set(17)
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/smithy-gradle-plugin.plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-gradle-plugin.plugin-conventions.gradle.kts
@@ -9,6 +9,9 @@ plugins {
     id("com.github.spotbugs")
 }
 
+// Workaround per: https://github.com/gradle/gradle/issues/15383
+val Project.libs get() = the<org.gradle.accessors.dm.LibrariesForLibs>()
+
 /*
  * Common plugin settings
  * ====================================================
@@ -67,10 +70,10 @@ publishing {
  * ====================================================
  */
 dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.4.0")
-    testImplementation("org.hamcrest:hamcrest:2.1")
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testImplementation(libs.junit.jupiter.params)
+    testImplementation(libs.hamcrest)
     testImplementation(project(":integ-test-utils"))
 }
 

--- a/buildSrc/src/main/kotlin/smithy-gradle-plugin.plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-gradle-plugin.plugin-conventions.gradle.kts
@@ -110,6 +110,15 @@ sourceSets {
         runtimeClasspath += output + compileClasspath + sourceSets["test"].runtimeClasspath
     }
 }
+
+dependencies {
+    // JUnit's classes carry @API(status = ...) annotations defined in the compile-only
+    // apiguardian artifact. The `it` source set draws its compile classpath from
+    // testRuntimeClasspath, which omits compile-only deps, so add apiguardian directly to
+    // stop javac warning spam.
+    "itCompileOnly"(libs.apiguardian.api)
+}
+
 // Disable spotbugs and checkstyle for integration tests
 tasks["spotbugsIt"].enabled = false
 tasks["checkstyleIt"].enabled = false

--- a/buildSrc/src/main/kotlin/smithy-gradle-plugin.plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-gradle-plugin.plugin-conventions.gradle.kts
@@ -72,6 +72,7 @@ publishing {
 dependencies {
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.hamcrest)
     testImplementation(project(":integ-test-utils"))

--- a/buildSrc/src/main/kotlin/smithy-gradle-plugin.plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-gradle-plugin.plugin-conventions.gradle.kts
@@ -31,7 +31,7 @@ publishing {
     repositories {
         maven {
             name = "stagingRepository"
-            url = uri("${rootProject.buildDir}/staging")
+            url = uri(stagingDir())
         }
     }
     // Add license spec to all maven publications
@@ -151,7 +151,7 @@ tasks.jacocoTestReport {
     reports {
         xml.required.set(false)
         csv.required.set(false)
-        html.outputLocation.set(file("$buildDir/reports/jacoco"))
+        html.outputLocation.set(layout.buildDirectory.dir("reports/jacoco"))
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 junit = "6.1.1"
 hamcrest = "3.0"
+api-guardian = "1.1.2"
 smithy = "[1.60.2, 2.0["
 jreleaser = "1.25.0"
 spotbugs = "6.4.8"
@@ -18,6 +19,10 @@ junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", vers
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
+
+# JUnit annotates its API with @API(status = ...), a compile-only apiguardian type. Without this
+# javac will spam warnings about the status enum being missing.
+apiguardian-api = { module = "org.apiguardian:apiguardian-api", version.ref = "api-guardian" }
 
 spotbugs = { module = "com.github.spotbugs.snom:spotbugs-gradle-plugin", version.ref = "spotbugs" }
 test-logger = { module = "com.adarshr:gradle-test-logger-plugin", version.ref = "test-logger" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,26 @@
+[versions]
+junit = "5.4.0"
+hamcrest = "3.0"
+smithy = "[1.60.2, 2.0["
+jreleaser = "1.25.0"
+spotbugs = "6.4.8"
+test-logger = "4.0.0"
+plugin-publish = "1.3.1"
+
+[libraries]
+smithy-model = { module = "software.amazon.smithy:smithy-model", version.ref = "smithy" }
+smithy-build = { module = "software.amazon.smithy:smithy-build", version.ref = "smithy" }
+smithy-cli = { module = "software.amazon.smithy:smithy-cli", version.ref = "smithy" }
+
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
+
+hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
+
+spotbugs = { module = "com.github.spotbugs.snom:spotbugs-gradle-plugin", version.ref = "spotbugs" }
+test-logger = { module = "com.adarshr:gradle-test-logger-plugin", version.ref = "test-logger" }
+plugin-publish = { module = "com.gradle.publish:plugin-publish-plugin", version.ref = "plugin-publish" }
+
+[plugins]
+jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-junit = "5.4.0"
+junit = "6.1.1"
 hamcrest = "3.0"
 smithy = "[1.60.2, 2.0["
 jreleaser = "1.25.0"
@@ -15,6 +15,7 @@ smithy-cli = { module = "software.amazon.smithy:smithy-cli", version.ref = "smit
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 

--- a/integ-test-utils/build.gradle.kts
+++ b/integ-test-utils/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 
 dependencies {
     implementation(gradleTestKit())
-    implementation("org.junit.jupiter:junit-jupiter-api:5.4.0")
-    implementation("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-    implementation("org.junit.jupiter:junit-jupiter-params:5.4.0")
-    implementation("org.hamcrest:hamcrest:3.0")
+    implementation(libs.junit.jupiter.api)
+    implementation(libs.junit.jupiter.engine)
+    implementation(libs.junit.jupiter.params)
+    implementation(libs.hamcrest)
 }

--- a/integ-test-utils/build.gradle.kts
+++ b/integ-test-utils/build.gradle.kts
@@ -11,3 +11,10 @@ dependencies {
     implementation(libs.junit.jupiter.params)
     implementation(libs.hamcrest)
 }
+
+// Unlike the published plugins, this module's main sources are test-support helpers that
+// depend on JUnit 6, so they must be compiled against Java 17 rather than the Java 8 default
+// applied by the java-conventions plugin.
+tasks.compileJava {
+    options.release.set(17)
+}


### PR DESCRIPTION
This moves dependencies to a version catalog, as we do for our other repos. This makes it easier for us to centrally manage versions, and makes it easier for dependabot too. After I merged the dependabot config I noticed it was missing some entries and opening what amounted to dupe prs. This should address that.

While I was at it I also updated JUnit to JUnit6, which requires us to compile tests with java 17. We did the same sort of split in smithy, where published sources are still targeting jdk8.

I also fixed a few warnings I noticed in the builds.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
