### PR TITLE
Explicitly declare cacheability of tasks

### DIFF
--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/AbstractSmithyCliTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/AbstractSmithyCliTask.java
@@ -20,6 +20,8 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.work.DisableCachingByDefault;
@@ -107,6 +109,7 @@ abstract class AbstractSmithyCliTask extends DefaultTask {
      */
     @InputFiles
     @Optional
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract Property<FileCollection> getModels();
 
     /**

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyBuildTask.java
@@ -24,7 +24,10 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 import software.amazon.smithy.cli.BuildParameterBuilder;
 import software.amazon.smithy.gradle.SmithyUtils;
 import software.amazon.smithy.model.validation.Severity;
@@ -36,6 +39,9 @@ import software.amazon.smithy.model.validation.Severity;
  * as task inputs.
  *
  */
+// Validation events written to smithy-build-info.json embed absolute source paths, so the
+// outputs are not relocatable across machines and cannot be safely cached.
+@DisableCachingByDefault(because = "Build outputs embed absolute source paths and are not relocatable")
 public abstract class SmithyBuildTask extends AbstractSmithyCliTask {
     @Inject
     public SmithyBuildTask(ObjectFactory objectFactory, StartParameter startParameter) {
@@ -69,6 +75,7 @@ public abstract class SmithyBuildTask extends AbstractSmithyCliTask {
      * @return list of smithy-build config json files
      */
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract Property<FileCollection> getSmithyBuildConfigs();
 
     /**

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyFormatCheckTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyFormatCheckTask.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 import org.gradle.StartParameter;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 import software.amazon.smithy.utils.ListUtils;
 
 
@@ -29,6 +30,7 @@ import software.amazon.smithy.utils.ListUtils;
  *
  * @see SmithyFormatTask
  */
+@DisableCachingByDefault(because = "Only verifies formatting and has no cacheable outputs")
 public abstract class SmithyFormatCheckTask extends SmithyFormatTask {
     private static final String DESCRIPTION = "Checks that smithy models are formatted.";
 

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyFormatTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyFormatTask.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 import org.gradle.StartParameter;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 import software.amazon.smithy.utils.ListUtils;
 
 
@@ -28,6 +29,7 @@ import software.amazon.smithy.utils.ListUtils;
  *
  * @see SmithyFormatCheckTask
  */
+@DisableCachingByDefault(because = "Formats source files in place and has no cacheable outputs")
 public abstract class SmithyFormatTask extends AbstractSmithyCliTask {
     private static final String DESCRIPTION = "Formats smithy models.";
 

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/tasks/SmithyValidateTask.java
@@ -17,7 +17,10 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 import software.amazon.smithy.model.validation.Severity;
 
 
@@ -29,6 +32,7 @@ import software.amazon.smithy.model.validation.Severity;
  * generated JAR works correctly when used alongside its dependencies.
  *
  */
+@DisableCachingByDefault(because = "Only validates models and has no cacheable outputs")
 public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
     private static final String DESCRIPTION = "Validates smithy models.";
 
@@ -50,6 +54,7 @@ public abstract class SmithyValidateTask extends AbstractSmithyCliTask {
      * @return file collection to use as sources for the validate task.
      */
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract Property<FileCollection> getSources();
 
     /**

--- a/smithy-jar/src/main/java/software/amazon/smithy/gradle/tasks/SmithyJarStagingTask.java
+++ b/smithy-jar/src/main/java/software/amazon/smithy/gradle/tasks/SmithyJarStagingTask.java
@@ -21,7 +21,10 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 import software.amazon.smithy.gradle.SmithyUtils;
 
 
@@ -35,6 +38,7 @@ import software.amazon.smithy.gradle.SmithyUtils;
  * <p>The temporary staging directory created by this task is named {@code staging-$TaskName}
  * in order to ensure that multiple staging tasks can be run without naming collisions.
  */
+@DisableCachingByDefault(because = "Staging is a cheap copy of build outputs and is not worth caching")
 public abstract class SmithyJarStagingTask extends DefaultTask {
     private static final String DESCRIPTION = "Stages smithy models for addition to a jar file.";
     private static final String SOURCES_PLUGIN_NAME = "sources";
@@ -58,6 +62,7 @@ public abstract class SmithyJarStagingTask extends DefaultTask {
      *
      */
     @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract DirectoryProperty getInputDirectory();
 
     /**

--- a/smithy-trait-package/src/main/java/software/amazon/smithy/gradle/tasks/MergeSpiFilesTask.java
+++ b/smithy-trait-package/src/main/java/software/amazon/smithy/gradle/tasks/MergeSpiFilesTask.java
@@ -21,7 +21,10 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 
 
 /**
@@ -31,6 +34,7 @@ import org.gradle.api.tasks.TaskAction;
  *
  * @see <a href="https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html">Java Service Provider Interface Introduction</a>
  */
+@DisableCachingByDefault(because = "Merging a handful of SPI files is not worth caching")
 public abstract class MergeSpiFilesTask extends DefaultTask {
     private static final String DESCRIPTION = "Merges two Java Service Provider Files.";
 
@@ -44,12 +48,14 @@ public abstract class MergeSpiFilesTask extends DefaultTask {
      * Generated Service Provider file to merge with existing file.
      */
     @InputFile
+    @PathSensitive(PathSensitivity.NAME_ONLY)
     public abstract RegularFileProperty getGeneratedFile();
 
     /**
      * Existing Service Provider file to merge with generated file.
      */
     @InputFile
+    @PathSensitive(PathSensitivity.NAME_ONLY)
     public abstract RegularFileProperty getExistingFile();
 
     /**


### PR DESCRIPTION
Gradle is getting more serious about caching, and as of Gradle 9 it is required for tasks to explicitly declare caching metadata. This adds any missing caching information to tasks and their inputs to conform to that expectation.

In gradle 8 tasks that don't delcare this information are considered un-cacheable and inputs that don't will cause misses for anything.

Note that the tasks are only declared as not caching *by default*. So a user can turn on caching if they want, and the extra context this gives to the inputs will make sure that works as well as can be expected.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
