### PR TITLE
Remove 'current' from gradle ci matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         gradle:
           - '8.2'      # Our declared minimum version
           - 'wrapper'  # The version in our gradle wrapper
-          - 'current'  # The current stable release
 
     steps:
       - name: Checkout smithy-gradle-plugin


### PR DESCRIPTION
This removes `current` from the gradle ci matrix. That was briefly needed while we were fixing the issues that kept us from building on current, but now that those are gone this isn't necessary. Dependabot will ensure we keep the wrapper version updated, so we should always be on current now. Maybe when gradle 10 comes out we add it back for a bit.

Note that we still run integ tests with 8.2 in the matrix, so we're not losing old version coverage.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
