### PR TITLE
Add cooldown config to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "wednesday"
+      time: "10:00"
+    cooldown:
+      default-days: 7
     labels:
      - "dependencies"
+
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
+      time: "10:00"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "software.amazon.smithy:smithy-model"
+        - "software.amazon.smithy:smithy-build"
+        - "software.amazon.smithy:smithy-cli"
     labels:
      - "dependencies"
      - "no-changelog-needed"


### PR DESCRIPTION
This adds a cooldown setting to dependabot to have it wait a week before pulling in any given update, excluding the smithy deps. It also sets the time consistently to fire early enough that EU folks see it in the morning.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
