### PR TITLE
Fix Smithy CLI thread context class loader

### DIFF
--- a/examples/base-plugin/service-loader-classloading/build.gradle.kts
+++ b/examples/base-plugin/service-loader-classloading/build.gradle.kts
@@ -1,0 +1,27 @@
+// This example verifies code loaded by the real Smithy CLI can use default ServiceLoader discovery.
+
+plugins {
+    id("java-library")
+    id("software.amazon.smithy.gradle.smithy-base").version("1.4.0")
+}
+
+group = "software.amazon.smithy"
+version = "9.9.9"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    smithyBuild(project(":service-loader-plugin"))
+}
+
+smithy {
+    format.set(false)
+}

--- a/examples/base-plugin/service-loader-classloading/model/main.smithy
+++ b/examples/base-plugin/service-loader-classloading/model/main.smithy
@@ -1,0 +1,5 @@
+namespace smithy.example
+
+structure Example {
+    value: String
+}

--- a/examples/base-plugin/service-loader-classloading/service-loader-plugin/build.gradle.kts
+++ b/examples/base-plugin/service-loader-classloading/service-loader-plugin/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id("java-library")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly("software.amazon.smithy:smithy-build:[1.0, 2.0[")
+}

--- a/examples/base-plugin/service-loader-classloading/service-loader-plugin/src/main/java/software/amazon/smithy/gradle/examples/ServiceLoaderProbePlugin.java
+++ b/examples/base-plugin/service-loader-classloading/service-loader-plugin/src/main/java/software/amazon/smithy/gradle/examples/ServiceLoaderProbePlugin.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.gradle.examples;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.build.SmithyBuildPlugin;
+import software.amazon.smithy.gradle.examples.spi.ServiceLoaderProbe;
+
+public final class ServiceLoaderProbePlugin implements SmithyBuildPlugin {
+    @Override
+    public String getName() {
+        return "service-loader-probe";
+    }
+
+    @Override
+    public void execute(PluginContext context) {
+        List<ServiceLoaderProbe> probes = new ArrayList<>();
+        ServiceLoader.load(ServiceLoaderProbe.class).forEach(probes::add);
+
+        if (probes.size() != 1) {
+            throw new IllegalStateException("Expected exactly one ServiceLoaderProbe provider but found "
+                    + probes.size());
+        }
+
+        probes.get(0).run();
+    }
+}

--- a/examples/base-plugin/service-loader-classloading/service-loader-plugin/src/main/java/software/amazon/smithy/gradle/examples/spi/DefaultServiceLoaderProbe.java
+++ b/examples/base-plugin/service-loader-classloading/service-loader-plugin/src/main/java/software/amazon/smithy/gradle/examples/spi/DefaultServiceLoaderProbe.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.gradle.examples.spi;
+
+public final class DefaultServiceLoaderProbe implements ServiceLoaderProbe {
+    @Override
+    public void run() {}
+}

--- a/examples/base-plugin/service-loader-classloading/service-loader-plugin/src/main/java/software/amazon/smithy/gradle/examples/spi/ServiceLoaderProbe.java
+++ b/examples/base-plugin/service-loader-classloading/service-loader-plugin/src/main/java/software/amazon/smithy/gradle/examples/spi/ServiceLoaderProbe.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.gradle.examples.spi;
+
+public interface ServiceLoaderProbe {
+    void run();
+}

--- a/examples/base-plugin/service-loader-classloading/service-loader-plugin/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
+++ b/examples/base-plugin/service-loader-classloading/service-loader-plugin/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
@@ -1,0 +1,1 @@
+software.amazon.smithy.gradle.examples.ServiceLoaderProbePlugin

--- a/examples/base-plugin/service-loader-classloading/service-loader-plugin/src/main/resources/META-INF/services/software.amazon.smithy.gradle.examples.spi.ServiceLoaderProbe
+++ b/examples/base-plugin/service-loader-classloading/service-loader-plugin/src/main/resources/META-INF/services/software.amazon.smithy.gradle.examples.spi.ServiceLoaderProbe
@@ -1,0 +1,1 @@
+software.amazon.smithy.gradle.examples.spi.DefaultServiceLoaderProbe

--- a/examples/base-plugin/service-loader-classloading/settings.gradle.kts
+++ b/examples/base-plugin/service-loader-classloading/settings.gradle.kts
@@ -1,0 +1,12 @@
+rootProject.name = "service-loader-classloading"
+
+include(":service-loader-plugin")
+
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        // Uncomment these to use the published version of the plugin from your preferred source.
+        // gradlePluginPortal()
+    }
+}

--- a/examples/base-plugin/service-loader-classloading/smithy-build.json
+++ b/examples/base-plugin/service-loader-classloading/smithy-build.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "plugins": {
+    "service-loader-probe": {}
+  }
+}

--- a/smithy-base/src/it/java/software/amazon/smithy/gradle/ServiceLoaderClassLoaderTest.java
+++ b/smithy-base/src/it/java/software/amazon/smithy/gradle/ServiceLoaderClassLoaderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.gradle;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for default ServiceLoader usage inside code loaded by the Smithy CLI.
+ *
+ * <p>The build plugin calls ServiceLoader.load(...) without an explicit class loader,
+ * so it depends on the Gradle plugin setting the thread context class loader to the
+ * same loader that loaded Smithy.
+ */
+public class ServiceLoaderClassLoaderTest {
+    @Test
+    public void buildPluginCanUseDefaultServiceLoader() {
+        Utils.withCopy("base-plugin/service-loader-classloading", buildDir -> {
+            BuildResult result = Utils.createGradleRunner()
+                    .forwardOutput()
+                    .withProjectDir(buildDir)
+                    .withArguments("clean", "build", "--stacktrace")
+                    .build();
+
+            Utils.assertSmithyBuildTaskRan(result);
+            Utils.assertArtifactsCreated(buildDir,
+                    "build/smithyprojections/service-loader-classloading/source/build-info/smithy-build-info.json",
+                    "build/smithyprojections/service-loader-classloading/source/model/model.json",
+                    "build/smithyprojections/service-loader-classloading/source/sources/main.smithy",
+                    "build/smithyprojections/service-loader-classloading/source/sources/manifest");
+
+            Assertions.assertFalse(
+                    result.getOutput().contains("not a subtype"),
+                    "Unexpected ServiceLoader class loading failure in output:\n" + result.getOutput());
+            Assertions.assertFalse(
+                    result.getOutput().contains("ServiceConfigurationError"),
+                    "Unexpected ServiceLoader class loading failure in output:\n" + result.getOutput());
+        });
+    }
+}

--- a/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
+++ b/smithy-base/src/main/java/software/amazon/smithy/gradle/SmithyUtils.java
@@ -157,29 +157,37 @@ public final class SmithyUtils {
         @Override
         public void execute() {
             withClassloader(getParameters().getClassPath().getFiles(), classLoader -> {
-                withCacheBuster(() -> {
-                    try {
-                        Class<?> smithyCliClass = classLoader.loadClass("software.amazon.smithy.cli.SmithyCli");
-                        Object cli = smithyCliClass.getDeclaredMethod("create").invoke(null);
-                        smithyCliClass.getDeclaredMethod("run", List.class)
-                                .invoke(cli, getParameters().getArguments().get());
-                    } catch (ReflectiveOperationException e) {
-                        // Unwrap to the root cause message. We intentionally do NOT reuse
-                        // unwrapException() here and do NOT attach the cause to GradleException:
-                        // smithy-model types (e.g. ModelSyntaxException, which references ShapeId)
-                        // are loaded only in the isolated URLClassLoader, so Gradle's daemon
-                        // serializer cannot see them. Attaching the cause chain would produce a
-                        // secondary NoClassDefFoundError that obscures the real error.
-                        Throwable cause = e;
-                        while (cause.getCause() != null) {
-                            cause = cause.getCause();
+                Thread thread = Thread.currentThread();
+                ClassLoader previous = thread.getContextClassLoader();
+                try {
+                    // Downstream Smithy can rely on thread context class loader.
+                    thread.setContextClassLoader(classLoader);
+                    withCacheBuster(() -> {
+                        try {
+                            Class<?> smithyCliClass = classLoader.loadClass("software.amazon.smithy.cli.SmithyCli");
+                            Object cli = smithyCliClass.getDeclaredMethod("create").invoke(null);
+                            smithyCliClass.getDeclaredMethod("run", List.class)
+                                    .invoke(cli, getParameters().getArguments().get());
+                        } catch (ReflectiveOperationException e) {
+                            // Unwrap to the root cause message. We intentionally do NOT reuse
+                            // unwrapException() here and do NOT attach the cause to GradleException:
+                            // smithy-model types (e.g. ModelSyntaxException, which references ShapeId)
+                            // are loaded only in the isolated URLClassLoader, so Gradle's daemon
+                            // serializer cannot see them. Attaching the cause chain would produce a
+                            // secondary NoClassDefFoundError that obscures the real error.
+                            Throwable cause = e;
+                            while (cause.getCause() != null) {
+                                cause = cause.getCause();
+                            }
+                            String message = cause.getMessage() != null
+                                    ? cause.getMessage()
+                                    : cause.getClass().getName();
+                            throw new GradleException(message);
                         }
-                        String message = cause.getMessage() != null
-                                ? cause.getMessage()
-                                : cause.getClass().getName();
-                        throw new GradleException(message);
-                    }
-                });
+                    });
+                } finally {
+                    thread.setContextClassLoader(previous);
+                }
             });
         }
     }


### PR DESCRIPTION
#### Background
The Gradle plugin invokes the Smithy CLI from a classloader-isolated Gradle worker, then loads Smithy itself from a custom `URLClassLoader`. Some Smithy code can rely on the thread context classloader, including default `ServiceLoader.load(...)` calls. When the thread context classloader still points at Gradle’s worker loader, provider lookup can load providers from a different classloader than the service interface and fail with `Provider ... not a subtype`.

This change temporarily sets the thread context classloader to the custom Smithy loader while invoking the CLI, then restores the previous loader.

#### Testing
Added a regression test that runs the real Smithy CLI with a tiny build plugin that intentionally calls default `ServiceLoader.load(...)`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
