### PR TITLE
Wire integTest behind pTML

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,18 @@ allprojects {
 }
 println("Smithy Gradle version: '${pluginVersion}'")
 
+// Create a single task that covers publishing each plugin, current and future, to mavenLocal.
+// This task should be a dependency of plugin integration tests to ensure all of the plugins
+// for running the tests are in sync.
+val publishPluginsToMavenLocal = tasks.register("publishPluginsToMavenLocal")
+subprojects {
+    plugins.withId("smithy-gradle-plugin.plugin-conventions") {
+        publishPluginsToMavenLocal.configure {
+            dependsOn(tasks.named("publishToMavenLocal"))
+        }
+    }
+}
+
 /*
  * Jreleaser (https://jreleaser.org) config.
  */

--- a/buildSrc/src/main/kotlin/smithy-gradle-plugin.plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/smithy-gradle-plugin.plugin-conventions.gradle.kts
@@ -139,7 +139,9 @@ tasks.register<Test>("integTest") {
 }
 
 afterEvaluate {
-    tasks["integTest"].dependsOn("publishToMavenLocal")
+    // Require that all of the plugins are published before running integration tests,
+    // ensuring that mismatches due to Gradle sequencing don't occur.
+    tasks["integTest"].dependsOn(rootProject.tasks.named("publishPluginsToMavenLocal"))
 
     // Always run javadoc and integration tests after build.
     tasks["assemble"].dependsOn("javadoc")


### PR DESCRIPTION
Introduce a singular publishPluginsToMavenLocal task to ensure that plugins are published before integTest runs to ensure changes are in sync.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
